### PR TITLE
[Feat] Pattern 페이지에 inline, block 스타일 버튼으로 변경할 수 있도록 툴바 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.11.3",
+    "@material-ui/icons": "^4.11.2",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
@@ -49,7 +50,9 @@
     ]
   },
   "devDependencies": {
+    "@draft-js-plugins/buttons": "^4.1.0",
     "@draft-js-plugins/editor": "^4.1.0",
+    "@draft-js-plugins/static-toolbar": "^4.1.0",
     "@storybook/addon-actions": "^6.1.21",
     "@storybook/addon-docs": "^6.1.21",
     "@storybook/addon-knobs": "^6.1.21",

--- a/src/pages/CreateDesign/Pattern/index.tsx
+++ b/src/pages/CreateDesign/Pattern/index.tsx
@@ -1,5 +1,18 @@
+import {
+  ItalicButton,
+  BoldButton,
+  UnderlineButton,
+  CodeButton,
+  UnorderedListButton,
+  OrderedListButton,
+  BlockquoteButton,
+  CodeBlockButton,
+} from '@draft-js-plugins/buttons';
 import Editor from '@draft-js-plugins/editor';
-import { EditorState } from 'draft-js';
+import createToolbarPlugin, {
+  Separator,
+} from '@draft-js-plugins/static-toolbar';
+import { DraftStyleMap, EditorState } from 'draft-js';
 import createUnitDecoratorPlugin from 'plugins/unitDecorator';
 import { UnitDecoratorStyleMap } from 'plugins/unitDecorator/types';
 import { useRef, useState } from 'react';
@@ -7,8 +20,15 @@ import styled, { css } from 'styled-components';
 import { theme } from 'themes';
 import { palette } from 'themes/palatte';
 
+import { FontSize } from '../components/FontSize';
+
+import { defaultFontSize } from './types';
+import { getCurrentFontSize } from './utils';
+
 const stitcheDecoratorPlugin = createUnitDecoratorPlugin({ unit: '코' });
 const rowDecoratorPlugin = createUnitDecoratorPlugin({ unit: '단' });
+const toolbarPlugin = createToolbarPlugin();
+const { Toolbar } = toolbarPlugin;
 
 interface EditorWrapperProps {
   isFocused: boolean;
@@ -17,7 +37,7 @@ interface EditorWrapperProps {
 const EditorWrapper = styled.div<EditorWrapperProps>`
   min-height: 50%;
   padding: ${theme.spacing(1.5)};
-  margin: ${theme.spacing(4, 1.5)};
+  margin: ${theme.spacing(1, 1.5, 4, 1.5)};
   border: 1.5px solid transparent;
   border-radius: ${theme.spacing(1)};
   background: ${palette.grey[200]};
@@ -41,25 +61,85 @@ const EditorWrapper = styled.div<EditorWrapperProps>`
   }
 `;
 
+const ToolbarContentWrapper = styled.div`
+  display: flex;
+  margin: ${theme.spacing(4, 1.5, 0, 1.5)};
+  padding: ${theme.spacing(0.5)};
+  background: ${palette.grey[200]};
+  border-radius: ${theme.spacing(1)};
+
+  button {
+    height: 100%;
+    background: transparent;
+    border-radius: ${theme.spacing(0.5)};
+    border: none;
+    cursor: pointer;
+
+    &:hover {
+      background: ${palette.grey[300]};
+    }
+  }
+`;
+
 const Pattern = (): React.ReactElement => {
   const [editorState, setEditorState] = useState<EditorState>(
     EditorState.createEmpty(),
   );
+
+  const [customStyleMap, setCustomStyleMap] = useState<DraftStyleMap>({
+    CODE: {
+      fontFamily: 'monospace',
+      wordWrap: 'break-word',
+      background: palette.grey[300],
+      color: palette.primary.main,
+      borderRadius: theme.spacing(1),
+      padding: theme.spacing(0.3, 0.7),
+    },
+    ...UnitDecoratorStyleMap,
+  });
+
+  const [currentFontSize, setCurrentFontSize] = useState(
+    getCurrentFontSize(editorState, customStyleMap),
+  );
   const [isFocused, setIsFocused] = useState(false);
   const editor = useRef<Editor | null>(null);
 
-  const plugins = [stitcheDecoratorPlugin, rowDecoratorPlugin];
+  const plugins = [stitcheDecoratorPlugin, rowDecoratorPlugin, toolbarPlugin];
 
   const focusEditor = (): void => {
     editor?.current?.focus();
   };
 
-  const customStyleMap = {
-    ...UnitDecoratorStyleMap,
+  const changeFontSize = (newCustomStyleMap: DraftStyleMap): void => {
+    setCurrentFontSize(getCurrentFontSize(editorState, newCustomStyleMap));
+    setCustomStyleMap(newCustomStyleMap);
   };
 
   return (
     <>
+      <Toolbar>
+        {(externalProps) => (
+          <ToolbarContentWrapper>
+            <BoldButton {...externalProps} />
+            <ItalicButton {...externalProps} />
+            <UnderlineButton {...externalProps} />
+            <CodeButton {...externalProps} />
+            <Separator />
+            <UnorderedListButton {...externalProps} />
+            <OrderedListButton {...externalProps} />
+            <BlockquoteButton {...externalProps} />
+            <CodeBlockButton {...externalProps} />
+            <Separator />
+            <FontSize
+              defaultFontSize={defaultFontSize}
+              fontSize={currentFontSize}
+              editorState={editorState}
+              onChange={setEditorState}
+              onChageCustomStyleMap={changeFontSize}
+            />
+          </ToolbarContentWrapper>
+        )}
+      </Toolbar>
       <EditorWrapper onClick={focusEditor} isFocused={isFocused}>
         <Editor
           ref={editor}

--- a/src/pages/CreateDesign/Pattern/index.tsx
+++ b/src/pages/CreateDesign/Pattern/index.tsx
@@ -104,6 +104,11 @@ const Pattern = (): React.ReactElement => {
   const [isFocused, setIsFocused] = useState(false);
   const editor = useRef<Editor | null>(null);
 
+  stitcheDecoratorPlugin.onChange = (editState: EditorState): EditorState => {
+    setEditorState(editState);
+    return editState;
+  };
+
   const plugins = [stitcheDecoratorPlugin, rowDecoratorPlugin, toolbarPlugin];
 
   const focusEditor = (): void => {

--- a/src/pages/CreateDesign/Pattern/types.ts
+++ b/src/pages/CreateDesign/Pattern/types.ts
@@ -1,0 +1,1 @@
+export const defaultFontSize = 16;

--- a/src/pages/CreateDesign/Pattern/utils.ts
+++ b/src/pages/CreateDesign/Pattern/utils.ts
@@ -1,0 +1,21 @@
+import { DraftStyleMap, EditorState } from 'draft-js';
+import { getSelectionCustomInlineStyle } from 'pages/libs/draftjs-utils/inline';
+
+import { defaultFontSize } from './types';
+
+export const getCurrentFontSize = (
+  editorState: EditorState,
+  customStyleMap: DraftStyleMap,
+): number | undefined => {
+  const selectionCustomInlineStyle = getSelectionCustomInlineStyle(
+    editorState,
+    ['FONTSIZE'],
+  );
+
+  return Object.keys(selectionCustomInlineStyle).includes('FONTSIZE')
+    ? Number(
+        customStyleMap[selectionCustomInlineStyle.FONTSIZE]?.fontSize ??
+          defaultFontSize,
+      )
+    : undefined;
+};

--- a/src/pages/CreateDesign/components/DropDown/DropDownOption/index.tsx
+++ b/src/pages/CreateDesign/components/DropDown/DropDownOption/index.tsx
@@ -23,12 +23,10 @@ export const DropdownOption = ({
 }: Props): React.ReactElement => {
   const handleClick: MenuItemProps['onClick'] = (event): void => {
     if (!disabled) {
-      if (onSelect) {
-        onSelect?.(value);
-      }
+      onSelect?.(value);
       if (onClick) {
         event.stopPropagation();
-        onClick?.(value);
+        onClick(value);
       }
     }
   };

--- a/src/pages/CreateDesign/components/DropDown/DropDownOption/index.tsx
+++ b/src/pages/CreateDesign/components/DropDown/DropDownOption/index.tsx
@@ -1,0 +1,41 @@
+import { MenuItem, MenuItemProps } from '@material-ui/core';
+import React from 'react';
+
+interface Props {
+  onSelect?(value: number): void;
+  onClick?(value: number): void;
+
+  active: boolean;
+  disabled?: boolean;
+  value: number;
+  key: string;
+  children: React.ReactNode;
+}
+
+export const DropdownOption = ({
+  onSelect,
+  onClick,
+  active,
+  disabled,
+  value,
+  key,
+  children,
+}: Props): React.ReactElement => {
+  const handleClick: MenuItemProps['onClick'] = (event): void => {
+    if (!disabled) {
+      if (onSelect) {
+        onSelect?.(value);
+      }
+      if (onClick) {
+        event.stopPropagation();
+        onClick?.(value);
+      }
+    }
+  };
+
+  return (
+    <MenuItem value={value} key={key} onClick={handleClick} selected={active}>
+      {children}
+    </MenuItem>
+  );
+};

--- a/src/pages/CreateDesign/components/DropDown/index.tsx
+++ b/src/pages/CreateDesign/components/DropDown/index.tsx
@@ -1,0 +1,102 @@
+import { MenuList, MenuListProps } from '@material-ui/core';
+import {
+  ArrowDropDown as ArrowDropDownIcon,
+  ArrowDropUp as ArrowDropUpIcon,
+} from '@material-ui/icons';
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { theme } from 'themes';
+import { palette } from 'themes/palatte';
+
+const DropDownWrapper = styled.div`
+  height: ${theme.spacing(4)};
+`;
+
+const SelectedButton = styled.button`
+  display: flex;
+  position: relative;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  padding: ${theme.spacing(0.5, 1, 0.5, 1.5)};
+`;
+
+const OptionWrapper = styled(MenuList)`
+  background: ${palette.background.paper};
+  max-height: ${theme.spacing(27)};
+  border-radius: ${theme.spacing(0.5)};
+  box-shadow: ${theme.shadows[8]};
+  overflow-y: scroll;
+`;
+
+interface Props {
+  onChange(value: number): void;
+  value?: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  children: any;
+}
+
+export const DropDown = ({
+  onChange,
+  value,
+  children,
+}: Props): React.ReactElement => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const currentValue = value;
+
+  const handleListOpen = (event: React.MouseEvent<HTMLButtonElement>): void => {
+    event.preventDefault();
+    setIsOpen(true);
+  };
+
+  const preventBubblingUp = (event: React.MouseEvent<HTMLDivElement>): void => {
+    event.preventDefault();
+  };
+
+  const stopPropagation: MenuListProps['onClick'] = (event): void => {
+    event.stopPropagation();
+  };
+
+  const handleChange = (selectedValue: number): void => {
+    setIsOpen(!isOpen);
+    onChange(selectedValue);
+  };
+  const childrens = children.slice(1, children.length);
+
+  useEffect(() => {
+    const handleClick = (): void => {
+      setIsOpen(!isOpen);
+    };
+
+    if (isOpen) {
+      document.addEventListener('click', handleClick);
+    }
+    return (): void => {
+      document.removeEventListener('click', handleClick);
+    };
+  }, [isOpen]);
+
+  return (
+    <DropDownWrapper onMouseDown={preventBubblingUp}>
+      <SelectedButton onClick={handleListOpen}>
+        {currentValue}
+        {isOpen ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />}
+      </SelectedButton>
+      {isOpen && (
+        <OptionWrapper onClick={stopPropagation}>
+          {React.Children.map(childrens, (option, index) => {
+            const temp =
+              option &&
+              React.cloneElement(option, {
+                onSelect: handleChange,
+                index,
+              });
+
+            return temp;
+          })}
+        </OptionWrapper>
+      )}
+    </DropDownWrapper>
+  );
+};

--- a/src/pages/CreateDesign/components/DropDown/index.tsx
+++ b/src/pages/CreateDesign/components/DropDown/index.tsx
@@ -86,14 +86,13 @@ export const DropDown = ({
       {isOpen && (
         <OptionWrapper onClick={stopPropagation}>
           {React.Children.map(childrens, (option, index) => {
-            const temp =
+            return (
               option &&
               React.cloneElement(option, {
                 onSelect: handleChange,
                 index,
-              });
-
-            return temp;
+              })
+            );
           })}
         </OptionWrapper>
       )}

--- a/src/pages/CreateDesign/components/FontSize/index.tsx
+++ b/src/pages/CreateDesign/components/FontSize/index.tsx
@@ -14,13 +14,13 @@ export const FontSize = ({
   fontSize,
 }: FontSizeProps): React.ReactElement => {
   const toggleFontSize = (newFontSize: number) => {
-    const newState = toggleCustomInlineStyle(
+    const newState = toggleCustomInlineStyle({
       editorState,
-      'fontSize',
-      newFontSize,
-      newFontSize === currentFontSize,
+      styleType: 'fontSize',
+      style: newFontSize,
+      isAlready: newFontSize === currentFontSize,
       onChageCustomStyleMap,
-    );
+    });
 
     if (newState) {
       onChange?.(newState);

--- a/src/pages/CreateDesign/components/FontSize/index.tsx
+++ b/src/pages/CreateDesign/components/FontSize/index.tsx
@@ -1,0 +1,60 @@
+import { toggleCustomInlineStyle } from 'pages/libs/draftjs-utils/inline';
+import React, { useEffect, useState } from 'react';
+
+import { DropDown } from '../DropDown';
+import { DropdownOption } from '../DropDown/DropDownOption';
+
+import { fontSizeOptions, FontSizeProps } from './types';
+
+export const FontSize = ({
+  onChange,
+  onChageCustomStyleMap,
+  editorState,
+  defaultFontSize,
+  fontSize,
+}: FontSizeProps): React.ReactElement => {
+  const toggleFontSize = (newFontSize: number) => {
+    const newState = toggleCustomInlineStyle(
+      editorState,
+      'fontSize',
+      newFontSize,
+      newFontSize === currentFontSize,
+      onChageCustomStyleMap,
+    );
+
+    if (newState) {
+      onChange?.(newState);
+    }
+  };
+
+  const [currentFontSize, setCurrentFontSize] = useState(
+    fontSize || defaultFontSize,
+  );
+
+  useEffect(() => {
+    setCurrentFontSize(fontSize || defaultFontSize);
+  }, [fontSize]);
+
+  return (
+    <DropDown
+      value={currentFontSize}
+      onChange={(size) => {
+        setCurrentFontSize(size === currentFontSize ? defaultFontSize : size);
+        toggleFontSize(size);
+      }}
+    >
+      {currentFontSize && <span>{currentFontSize}</span>}
+      {fontSizeOptions.map((size, index) => {
+        return (
+          <DropdownOption
+            active={currentFontSize === size}
+            value={size}
+            key={index.toString()}
+          >
+            {size}
+          </DropdownOption>
+        );
+      })}
+    </DropDown>
+  );
+};

--- a/src/pages/CreateDesign/components/FontSize/index.tsx
+++ b/src/pages/CreateDesign/components/FontSize/index.tsx
@@ -18,7 +18,7 @@ export const FontSize = ({
       editorState,
       styleType: 'fontSize',
       style: newFontSize,
-      isAlready: newFontSize === currentFontSize,
+      isAlreadyApplyed: newFontSize === currentFontSize,
       onChageCustomStyleMap,
     });
 

--- a/src/pages/CreateDesign/components/FontSize/types.ts
+++ b/src/pages/CreateDesign/components/FontSize/types.ts
@@ -1,0 +1,26 @@
+import { DraftStyleMap, EditorState } from 'draft-js';
+
+export type FontSizeProps = {
+  onChange?: (editorState: EditorState) => void;
+  onChageCustomStyleMap: (customStyleMap: DraftStyleMap) => void;
+
+  editorState: EditorState;
+  defaultFontSize: number;
+  fontSize?: number;
+};
+
+export const fontSizeOptions = [
+  8,
+  10,
+  12,
+  14,
+  16,
+  18,
+  24,
+  30,
+  36,
+  48,
+  60,
+  72,
+  96,
+];

--- a/src/pages/libs/draftjs-utils/block.ts
+++ b/src/pages/libs/draftjs-utils/block.ts
@@ -1,0 +1,26 @@
+import { ContentBlock, EditorState } from 'draft-js';
+
+export const getSelectedBlocksMap = (
+  editorState: EditorState,
+): Immutable.Iterable<string, ContentBlock> => {
+  const selectionState = editorState.getSelection();
+  const contentState = editorState.getCurrentContent();
+  const startKey = selectionState.getStartKey();
+  const endKey = selectionState.getEndKey();
+  const blockMap = contentState.getBlockMap();
+
+  return blockMap
+    .toSeq()
+    .skipUntil((_, k) => k === startKey)
+    .takeUntil((_, k) => k === endKey)
+    .concat([[endKey, blockMap.get(endKey)]]);
+};
+
+/**
+ * Function returns collection of currently selected blocks.
+ */
+export const getSelectedBlocksList = (
+  editorState: EditorState,
+): Immutable.List<ContentBlock> => {
+  return getSelectedBlocksMap(editorState).toList();
+};

--- a/src/pages/libs/draftjs-utils/block.ts
+++ b/src/pages/libs/draftjs-utils/block.ts
@@ -16,9 +16,6 @@ export const getSelectedBlocksMap = (
     .concat([[endKey, blockMap.get(endKey)]]);
 };
 
-/**
- * Function returns collection of currently selected blocks.
- */
 export const getSelectedBlocksList = (
   editorState: EditorState,
 ): Immutable.List<ContentBlock> => {

--- a/src/pages/libs/draftjs-utils/inline.ts
+++ b/src/pages/libs/draftjs-utils/inline.ts
@@ -1,0 +1,207 @@
+import {
+  ContentBlock,
+  DraftStyleMap,
+  EditorState,
+  Modifier,
+  RichUtils,
+} from 'draft-js';
+
+import { getSelectedBlocksList } from './block';
+
+export type StyleKeyType =
+  | 'color'
+  | 'bgcolor'
+  | 'fontSize'
+  | 'fontFamily'
+  | 'CODE'
+  | 'NOT_CALCULATE'
+  | 'FONTSIZE';
+
+type StyleMapType = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  color?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  bgcolor?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fontSize?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fontFamily?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  CODE?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  NOT_CALCULATE?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  FONTSIZE?: any;
+};
+
+const addToCustomStyleMap = (
+  styleType: StyleKeyType,
+  styleKey: string,
+  style: string | number,
+  onChageCustomStyleMap: (customStyleMap: DraftStyleMap) => void,
+): void => {
+  const newCustomInlineStylesMap = Object.assign(customInlineStylesMap, {
+    [`${styleType.toLowerCase()}-${style}`]: {
+      [`${styleKey}`]: style,
+    },
+  });
+
+  onChageCustomStyleMap(newCustomInlineStylesMap);
+};
+
+export const toggleCustomInlineStyle = (
+  editorState: EditorState,
+  styleType: StyleKeyType,
+  style: string | number,
+  isAlready: boolean,
+  onChageCustomStyleMap: (customStyleMap: DraftStyleMap) => void,
+): EditorState => {
+  const selection = editorState.getSelection();
+  const nextContentState = Object.keys(customInlineStylesMap[styleType]).reduce(
+    (contentState, inlineStyle) =>
+      Modifier.removeInlineStyle(contentState, selection, inlineStyle),
+    editorState.getCurrentContent(),
+  );
+  let nextEditorState = EditorState.push(
+    editorState,
+    nextContentState,
+    'change-inline-style',
+  );
+  const currentStyle = editorState.getCurrentInlineStyle();
+
+  if (selection.isCollapsed()) {
+    nextEditorState = currentStyle.reduce(
+      (state?: EditorState, inlineStyle?: string) => {
+        if (state != null && inlineStyle != null) {
+          return RichUtils.toggleInlineStyle(state, inlineStyle);
+        }
+        return editorState;
+      },
+      nextEditorState,
+    );
+  }
+
+  const styleKey = styleType === 'bgcolor' ? 'backgroundColor' : styleType;
+
+  if (!currentStyle.has(`${styleType}-${style}`)) {
+    nextEditorState = RichUtils.toggleInlineStyle(
+      nextEditorState,
+      `${styleType.toLowerCase()}-${style}`,
+    );
+    if (!isAlready) {
+      addToCustomStyleMap(styleType, styleKey, style, onChageCustomStyleMap);
+    }
+  }
+
+  return nextEditorState;
+};
+
+export const customInlineStylesMap: StyleMapType = {
+  color: {},
+  bgcolor: {},
+  fontSize: {},
+  fontFamily: {},
+  CODE: {},
+};
+
+const getCurrentInlineStyle = (
+  editorState: EditorState,
+  stylePrefix: string,
+): string | undefined => {
+  const styles = editorState.getCurrentInlineStyle().toList();
+
+  const filteredStyle = styles.filter(
+    (style) => style != null && style.startsWith(stylePrefix.toLowerCase()),
+  );
+
+  if (filteredStyle && filteredStyle.size > 0) {
+    return filteredStyle.get(0);
+  }
+
+  return undefined;
+};
+
+/**
+ * Function returns size at a offset.
+ */
+
+const getStyleAtOffset = (
+  block: ContentBlock,
+  stylePrefix: string,
+  offset: number,
+): string | undefined => {
+  const styles = block.getInlineStyleAt(offset).toList();
+  const filteredStyle = styles.filter(
+    (style) => style != null && style.startsWith(stylePrefix.toLowerCase()),
+  );
+
+  if (filteredStyle && filteredStyle.size > 0) {
+    return filteredStyle.get(0);
+  }
+
+  return undefined;
+};
+
+/**
+ * Function returns an object of custom inline styles currently applicable.
+ */
+
+export const getSelectionCustomInlineStyle = (
+  editorState: EditorState,
+  styles: StyleKeyType[],
+): StyleMapType => {
+  if (editorState && styles && styles.length > 0) {
+    const currentSelection = editorState.getSelection();
+    const inlineStyles: StyleMapType = {};
+
+    if (currentSelection.isCollapsed()) {
+      styles.forEach((style) => {
+        inlineStyles[style] = getCurrentInlineStyle(editorState, style);
+      });
+      return inlineStyles;
+    }
+    const start = currentSelection.getStartOffset();
+    const end = currentSelection.getEndOffset();
+    const selectedBlocks = getSelectedBlocksList(editorState);
+
+    if (selectedBlocks.size > 0) {
+      for (let index = 0; index < selectedBlocks.size; index += 1) {
+        let blockStart = index === 0 ? start : 0;
+        let blockEnd =
+          index === selectedBlocks.size - 1
+            ? end
+            : selectedBlocks.get(index).getText().length;
+
+        if (blockStart === blockEnd && blockStart === 0) {
+          blockStart = 1;
+          blockEnd = 2;
+        } else if (blockStart === blockEnd) {
+          blockStart -= 1;
+        }
+        for (let j = blockStart; j < blockEnd; j += 1) {
+          if (j === blockStart) {
+            styles.forEach((style) => {
+              inlineStyles[style] = getStyleAtOffset(
+                selectedBlocks.get(index),
+                style,
+                j,
+              );
+            });
+          } else {
+            styles.forEach((style) => {
+              if (
+                inlineStyles[style] &&
+                inlineStyles[style] !==
+                  getStyleAtOffset(selectedBlocks.get(index), style, j)
+              ) {
+                inlineStyles[style] = undefined;
+              }
+            });
+          }
+        }
+      }
+      return inlineStyles;
+    }
+  }
+  return {};
+};

--- a/src/pages/libs/draftjs-utils/inline.ts
+++ b/src/pages/libs/draftjs-utils/inline.ts
@@ -228,11 +228,13 @@ interface ChangeOriginalStyleToNeweStyle {
   editorState: EditorState;
   originalStyle: StyleKeyType;
   newStyle?: StyleKeyType;
+  blockKey?: string;
   startOffset?: number;
   endOffset?: number;
 }
 
 export const changeOriginalStyleToNeweStyle = ({
+  blockKey,
   editorState,
   originalStyle,
   newStyle,
@@ -240,7 +242,15 @@ export const changeOriginalStyleToNeweStyle = ({
   endOffset,
 }: ChangeOriginalStyleToNeweStyle): EditorState => {
   const selectionState = editorState.getSelection();
+  const originalSelection = selectionState.merge({
+    anchorKey: selectionState.getAnchorKey(),
+    focusKey: selectionState.getFocusKey(),
+    anchorOffset: selectionState.getAnchorOffset(),
+    focusOffset: selectionState.getFocusOffset(),
+  });
+
   const newSelection = selectionState.merge({
+    focusKey: blockKey,
     anchorOffset: startOffset,
     focusOffset: endOffset,
   });
@@ -257,18 +267,18 @@ export const changeOriginalStyleToNeweStyle = ({
 
   let editorStateWithNewStyle;
 
-  if (newStyle != null) {
+  if (newStyle == null) {
+    editorStateWithNewStyle = editorStateWithToggleOriginalStyle;
+  } else {
     editorStateWithNewStyle = RichUtils.toggleInlineStyle(
       editorStateWithToggleOriginalStyle,
       newStyle,
     );
-  } else {
-    editorStateWithNewStyle = editorStateWithToggleOriginalStyle;
   }
 
   const editorStateWithNewStyleAndPreviousSelection = EditorState.forceSelection(
     editorStateWithNewStyle,
-    selectionState,
+    originalSelection,
   );
 
   return editorStateWithNewStyleAndPreviousSelection;

--- a/src/pages/libs/draftjs-utils/inline.ts
+++ b/src/pages/libs/draftjs-utils/inline.ts
@@ -14,7 +14,8 @@ export type StyleKeyType =
   | 'fontSize'
   | 'fontFamily'
   | 'CODE'
-  | 'CALCULATE'
+  | 'STITCH_CALCULATE_ROUND'
+  | 'ROW_CALCULATE_ROUND'
   | 'NOT_CALCULATE'
   | 'FONTSIZE';
 
@@ -30,7 +31,9 @@ type StyleMapType = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   CODE?: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  CALCULATE?: any;
+  STITCH_CALCULATE_ROUND?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ROW_CALCULATE_ROUND?: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   NOT_CALCULATE?: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/pages/libs/draftjs-utils/inline.ts
+++ b/src/pages/libs/draftjs-utils/inline.ts
@@ -34,12 +34,19 @@ type StyleMapType = {
   FONTSIZE?: any;
 };
 
-const addToCustomStyleMap = (
-  styleType: StyleKeyType,
-  styleKey: string,
-  style: string | number,
-  onChageCustomStyleMap: (customStyleMap: DraftStyleMap) => void,
-): void => {
+interface AddToCustomStyleMap {
+  styleType: StyleKeyType;
+  styleKey: string;
+  style: string | number;
+  onChageCustomStyleMap: (customStyleMap: DraftStyleMap) => void;
+}
+
+const addToCustomStyleMap = ({
+  styleType,
+  styleKey,
+  style,
+  onChageCustomStyleMap,
+}: AddToCustomStyleMap): void => {
   const newCustomInlineStylesMap = Object.assign(customInlineStylesMap, {
     [`${styleType.toLowerCase()}-${style}`]: {
       [`${styleKey}`]: style,
@@ -49,13 +56,21 @@ const addToCustomStyleMap = (
   onChageCustomStyleMap(newCustomInlineStylesMap);
 };
 
-export const toggleCustomInlineStyle = (
-  editorState: EditorState,
-  styleType: StyleKeyType,
-  style: string | number,
-  isAlready: boolean,
-  onChageCustomStyleMap: (customStyleMap: DraftStyleMap) => void,
-): EditorState => {
+interface ToggleCustomInlineStyle {
+  editorState: EditorState;
+  styleType: StyleKeyType;
+  style: string | number;
+  isAlready: boolean;
+  onChageCustomStyleMap: (customStyleMap: DraftStyleMap) => void;
+}
+
+export const toggleCustomInlineStyle = ({
+  editorState,
+  styleType,
+  style,
+  isAlready,
+  onChageCustomStyleMap,
+}: ToggleCustomInlineStyle): EditorState => {
   const selection = editorState.getSelection();
   const nextContentState = Object.keys(customInlineStylesMap[styleType]).reduce(
     (contentState, inlineStyle) =>
@@ -89,7 +104,12 @@ export const toggleCustomInlineStyle = (
       `${styleType.toLowerCase()}-${style}`,
     );
     if (!isAlready) {
-      addToCustomStyleMap(styleType, styleKey, style, onChageCustomStyleMap);
+      addToCustomStyleMap({
+        styleType,
+        styleKey,
+        style,
+        onChageCustomStyleMap,
+      });
     }
   }
 

--- a/src/pages/libs/draftjs-utils/inline.ts
+++ b/src/pages/libs/draftjs-utils/inline.ts
@@ -147,10 +147,6 @@ const getCurrentInlineStyle = (
   return undefined;
 };
 
-/**
- * Function returns size at a offset.
- */
-
 const getStyleAtOffset = (
   block: ContentBlock,
   stylePrefix: string,
@@ -167,10 +163,6 @@ const getStyleAtOffset = (
 
   return undefined;
 };
-
-/**
- * Function returns an object of custom inline styles currently applicable.
- */
 
 export const getSelectionCustomInlineStyle = (
   editorState: EditorState,

--- a/src/pages/libs/draftjs-utils/inline.ts
+++ b/src/pages/libs/draftjs-utils/inline.ts
@@ -14,6 +14,7 @@ export type StyleKeyType =
   | 'fontSize'
   | 'fontFamily'
   | 'CODE'
+  | 'CALCULATE'
   | 'NOT_CALCULATE'
   | 'FONTSIZE';
 
@@ -28,6 +29,8 @@ type StyleMapType = {
   fontFamily?: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   CODE?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  CALCULATE?: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   NOT_CALCULATE?: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -224,4 +227,54 @@ export const getSelectionCustomInlineStyle = (
     }
   }
   return {};
+};
+
+interface ChangeOriginalStyleToNeweStyle {
+  editorState: EditorState;
+  originalStyle: StyleKeyType;
+  newStyle?: StyleKeyType;
+  startOffset?: number;
+  endOffset?: number;
+}
+
+export const changeOriginalStyleToNeweStyle = ({
+  editorState,
+  originalStyle,
+  newStyle,
+  startOffset,
+  endOffset,
+}: ChangeOriginalStyleToNeweStyle): EditorState => {
+  const selectionState = editorState.getSelection();
+  const newSelection = selectionState.merge({
+    anchorOffset: startOffset,
+    focusOffset: endOffset,
+  });
+
+  const editorStateWithNewSelection = EditorState.forceSelection(
+    editorState,
+    newSelection,
+  );
+
+  const editorStateWithToggleOriginalStyle = RichUtils.toggleInlineStyle(
+    editorStateWithNewSelection,
+    originalStyle,
+  );
+
+  let editorStateWithNewStyle;
+
+  if (newStyle != null) {
+    editorStateWithNewStyle = RichUtils.toggleInlineStyle(
+      editorStateWithToggleOriginalStyle,
+      newStyle,
+    );
+  } else {
+    editorStateWithNewStyle = editorStateWithToggleOriginalStyle;
+  }
+
+  const editorStateWithNewStyleAndPreviousSelection = EditorState.forceSelection(
+    editorStateWithNewStyle,
+    selectionState,
+  );
+
+  return editorStateWithNewStyleAndPreviousSelection;
 };

--- a/src/pages/libs/draftjs-utils/inline.ts
+++ b/src/pages/libs/draftjs-utils/inline.ts
@@ -224,7 +224,7 @@ export const getSelectionCustomInlineStyle = (
   return {};
 };
 
-interface ChangeOriginalStyleToNeweStyle {
+interface ChangeOriginalStyleToNewStyle {
   editorState: EditorState;
   originalStyle: StyleKeyType;
   newStyle?: StyleKeyType;
@@ -240,7 +240,7 @@ export const changeOriginalStyleToNeweStyle = ({
   newStyle,
   startOffset,
   endOffset,
-}: ChangeOriginalStyleToNeweStyle): EditorState => {
+}: ChangeOriginalStyleToNewStyle): EditorState => {
   const selectionState = editorState.getSelection();
   const originalSelection = selectionState.merge({
     anchorKey: selectionState.getAnchorKey(),

--- a/src/pages/libs/draftjs-utils/inline.ts
+++ b/src/pages/libs/draftjs-utils/inline.ts
@@ -63,7 +63,7 @@ interface ToggleCustomInlineStyle {
   editorState: EditorState;
   styleType: StyleKeyType;
   style: string | number;
-  isAlready: boolean;
+  isAlreadyApplyed: boolean;
   onChageCustomStyleMap: (customStyleMap: DraftStyleMap) => void;
 }
 
@@ -71,7 +71,7 @@ export const toggleCustomInlineStyle = ({
   editorState,
   styleType,
   style,
-  isAlready,
+  isAlreadyApplyed,
   onChageCustomStyleMap,
 }: ToggleCustomInlineStyle): EditorState => {
   const selection = editorState.getSelection();
@@ -106,7 +106,7 @@ export const toggleCustomInlineStyle = ({
       nextEditorState,
       `${styleType.toLowerCase()}-${style}`,
     );
-    if (!isAlready) {
+    if (!isAlreadyApplyed) {
       addToCustomStyleMap({
         styleType,
         styleKey,

--- a/src/plugins/unitDecorator/types.ts
+++ b/src/plugins/unitDecorator/types.ts
@@ -1,9 +1,5 @@
 import { palette } from 'themes/palatte';
 
-export const CustomInline = {
-  NOT_CALCULATE: 'NOT_CALCULATE',
-};
-
 export const UnitDecoratorStyleMap = {
   NOT_CALCULATE: {
     background: palette.action.disabledBackground,

--- a/src/plugins/unitDecorator/unitDecorator.tsx
+++ b/src/plugins/unitDecorator/unitDecorator.tsx
@@ -31,6 +31,7 @@ const DecoratorWrapper = styled.span`
     border-radius: ${theme.spacing(0.5)};
     color: ${theme.palette.background.paper};
     box-shadow: ${theme.shadows[2]};
+    line-height: 210%;
     cursor: pointer;
 
     &:hover {

--- a/src/plugins/unitDecorator/unitDecorator.tsx
+++ b/src/plugins/unitDecorator/unitDecorator.tsx
@@ -57,6 +57,8 @@ export default function UnitDecorator(props: UnitDecoratorProps): ReactElement {
   } = props;
 
   const editorState = getEditorState?.();
+  const calculateKey =
+    unit === '코' ? 'STITCH_CALCULATE_ROUND' : 'ROW_CALCULATE_ROUND';
 
   const selectionState = editorState.getSelection();
   const newSelection = selectionState.merge({
@@ -71,14 +73,14 @@ export default function UnitDecorator(props: UnitDecoratorProps): ReactElement {
 
   const currentStyle = editorStateWithNewSelection.getCurrentInlineStyle();
   const canCalculate =
-    !currentStyle.has('NOT_CALCULATE') && !currentStyle.has('CALCULATE');
+    !currentStyle.has('NOT_CALCULATE') && !currentStyle.has(calculateKey);
 
   useEffect(() => {
     if (setEditorState != null) {
       if (canCalculate) {
         const newEeditorState = changeOriginalStyleToNeweStyle({
           editorState,
-          originalStyle: 'CALCULATE',
+          originalStyle: calculateKey,
           startOffset: start,
           endOffset: end,
         });
@@ -92,7 +94,7 @@ export default function UnitDecorator(props: UnitDecoratorProps): ReactElement {
     if (editorState != null && children != null && setEditorState != null) {
       const newEeditorState = changeOriginalStyleToNeweStyle({
         editorState,
-        originalStyle: 'CALCULATE',
+        originalStyle: calculateKey,
         newStyle: 'NOT_CALCULATE',
         startOffset: start,
         endOffset: end,

--- a/src/plugins/unitDecorator/unitDecorator.tsx
+++ b/src/plugins/unitDecorator/unitDecorator.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { ContentState, convertToRaw, EditorState, RichUtils } from 'draft-js';
+import { ContentState, EditorState } from 'draft-js';
 import { changeOriginalStyleToNeweStyle } from 'pages/libs/draftjs-utils/inline';
 import { ReactElement, ReactNode, useEffect } from 'react';
 import styled from 'styled-components';
@@ -14,12 +14,12 @@ export interface UnitDecoratorProps {
   decoratedText?: string;
   entityKey?: string;
   offsetKey?: string;
-  contentState?: ContentState;
+  contentState: ContentState;
   blockKey?: string;
   start?: number;
   end?: number;
 
-  setEditorState?(editorState: EditorState): void;
+  setEditorState(editorState: EditorState): void;
   getEditorState(): EditorState;
 }
 
@@ -56,52 +56,52 @@ export default function UnitDecorator(props: UnitDecoratorProps): ReactElement {
     ...otherProps
   } = props;
 
-  const editorState = getEditorState?.();
+  const editorState = getEditorState();
   const calculateKey =
     unit === '코' ? 'STITCH_CALCULATE_ROUND' : 'ROW_CALCULATE_ROUND';
 
-  const selectionState = editorState.getSelection();
-  const newSelection = selectionState.merge({
-    anchorOffset: start,
-    focusOffset: end,
-  });
-
-  const editorStateWithNewSelection = EditorState.forceSelection(
-    editorState,
-    newSelection,
-  );
-
-  const currentStyle = editorStateWithNewSelection.getCurrentInlineStyle();
-  const canCalculate =
-    !currentStyle.has('NOT_CALCULATE') && !currentStyle.has(calculateKey);
-
   useEffect(() => {
-    if (setEditorState != null) {
-      if (canCalculate) {
-        const newEeditorState = changeOriginalStyleToNeweStyle({
-          editorState,
-          originalStyle: calculateKey,
-          startOffset: start,
-          endOffset: end,
-        });
+    const selectionState = editorState.getSelection();
+    const newSelection = selectionState.merge({
+      anchorKey: blockKey,
+      focusKey: blockKey,
+      anchorOffset: start,
+      focusOffset: end,
+    });
 
-        setEditorState(newEeditorState);
-      }
-    }
-  }, [canCalculate]);
+    const editorStateWithDecoratorSelection = EditorState.forceSelection(
+      editorState,
+      newSelection,
+    );
 
-  const handleClick = (): void => {
-    if (editorState != null && children != null && setEditorState != null) {
+    const decoratorStyle = editorStateWithDecoratorSelection.getCurrentInlineStyle();
+    const canCalculate =
+      !decoratorStyle.has('NOT_CALCULATE') && !decoratorStyle.has(calculateKey);
+
+    if (canCalculate) {
       const newEeditorState = changeOriginalStyleToNeweStyle({
         editorState,
+        blockKey,
         originalStyle: calculateKey,
-        newStyle: 'NOT_CALCULATE',
         startOffset: start,
         endOffset: end,
       });
 
       setEditorState(newEeditorState);
     }
+  }, [editorState]);
+
+  const handleClick = (): void => {
+    const newEeditorState = changeOriginalStyleToNeweStyle({
+      editorState: getEditorState(),
+      blockKey,
+      originalStyle: calculateKey,
+      newStyle: 'NOT_CALCULATE',
+      startOffset: start,
+      endOffset: end,
+    });
+
+    setEditorState(newEeditorState);
   };
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1448,6 +1448,13 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
+"@draft-js-plugins/buttons@^4.0.0", "@draft-js-plugins/buttons@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@draft-js-plugins/buttons/-/buttons-4.1.0.tgz#8a330fc93aa302caac9df9f888821ddacc975459"
+  integrity sha512-sGt5mSo6TwX53EYCHgF7KnwTJCT0OBHbWlvB0UG7aUSK2oiT2QD+z51o3d/BvM7105m/rdLA8WCeWW23tw771Q==
+  dependencies:
+    clsx "^1.0.4"
+
 "@draft-js-plugins/editor@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@draft-js-plugins/editor/-/editor-4.1.0.tgz#1861fb257ba51ecbd031b8a3d84ee0809de1504e"
@@ -1455,6 +1462,20 @@
   dependencies:
     immutable "~3.7.4"
     prop-types "^15.5.8"
+
+"@draft-js-plugins/static-toolbar@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@draft-js-plugins/static-toolbar/-/static-toolbar-4.1.0.tgz#b6dcbc18bd2f187ea26b44013076a998b0a8e2bd"
+  integrity sha512-p1oPopV/svcifwMOaOwLsQi37oZIv7UX9TTbVkpwYAAQ73Nws630Imm92tyEMy7bU5nxZ4PxiVMZ018MiGydlA==
+  dependencies:
+    "@draft-js-plugins/buttons" "^4.0.0"
+    "@draft-js-plugins/utils" "^4.0.0"
+    prop-types "^15.5.8"
+
+"@draft-js-plugins/utils@^4.0.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@draft-js-plugins/utils/-/utils-4.1.0.tgz#e63129c5678a9f150e2e07003fc866e779e982c4"
+  integrity sha512-bU1deEINlqHPX9+IqFyMT8EwDBsqn1o0C5U8VfhbVGXTuvTu/F0LI6XT2h7VD9ufoYK0s/BE6XBkyO+764Petg==
 
 "@emotion/cache@^10.0.27", "@emotion/cache@^10.0.9":
   version "10.0.29"
@@ -1814,6 +1835,13 @@
     prop-types "^15.7.2"
     react-is "^16.8.0 || ^17.0.0"
     react-transition-group "^4.4.0"
+
+"@material-ui/icons@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.11.2.tgz#b3a7353266519cd743b6461ae9fdfcb1b25eb4c5"
+  integrity sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
 
 "@material-ui/styles@^4.11.3":
   version "4.11.3"


### PR DESCRIPTION
## PR 제안 사유

<!--
아래 키워드 중 하나를 붙여 이슈를 자동으로 종료할 수 있도록 해주세요.
- Close
- Closes
- Closed
- Fix
- Fixes
- Fixed
- Resolve
- Resolves
- Resolved
-->

Close #33 
<!--
왜 이 PR을 제안하게 되었는지 간략하게 적어주세요.
이슈 내용만으로 설명이 된다면 생략 가능합니다.
-->

## 주요 변경 기록
- draft-js buttons, static-toolbar plugin인 추가
- DropDown과 DropdownOption 컴포넌트 추가
- draft-js-utils에 block, inline에서 필요한 부분만 추가
- react-draft-wysiwyg를 참조하여 FontSize 컴포넌트 추가
- Pattern 컴포넌트에 inline, block style button 적용

<!--
간단하게라도 적어주세요.
변경된 자세한 내용을 적어주셔도 좋습니다.
-->

## Code review

### Code review 에서 중점적으로 봐야하는 부분

<!-- 생략 가능합니다. -->

## Design review

### Design review 에서 중점적으로 봐야하는 부분 / 스크린샷
<img width="1680" alt="스크린샷 2021-04-18 오전 2 52 11" src="https://user-images.githubusercontent.com/26711037/115122097-16008680-9ff1-11eb-9dbd-5d15edacb638.png">
<img width="1680" alt="스크린샷 2021-04-18 오전 2 58 13" src="https://user-images.githubusercontent.com/26711037/115122259-edc55780-9ff1-11eb-97c3-a69ff4bf241c.png">
<!-- 생략 가능합니다. -->

## 기타 질문 및 특이 사항

<!-- 생략 가능합니다. -->
