### PR TITLE
[Feat] 코랑 단 클릭하면 내림, 올림, 반올림, 계산안함 선택하는 툴팁 뜨도록 

### DIFF
--- a/src/pages/libs/draftjs-utils/inline.ts
+++ b/src/pages/libs/draftjs-utils/inline.ts
@@ -18,6 +18,8 @@ export type StyleKeyType =
   | 'STITCH_CALCULATE_ROUND_UP'
   | 'STITCH_CALCULATE_ROUND_DOWN'
   | 'ROW_CALCULATE_ROUND'
+  | 'ROW_CALCULATE_ROUND_UP'
+  | 'ROW_CALCULATE_ROUND_DOWN'
   | 'NOT_CALCULATE'
   | 'FONTSIZE';
 
@@ -38,6 +40,10 @@ type StyleMapType = {
   STITCH_CALCULATE_ROUND_DOWN?: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   STITCH_CALCULATE_ROUND?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ROW_CALCULATE_ROUND_UP?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ROW_CALCULATE_ROUND_DOWN?: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ROW_CALCULATE_ROUND?: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/pages/libs/draftjs-utils/inline.ts
+++ b/src/pages/libs/draftjs-utils/inline.ts
@@ -15,6 +15,8 @@ export type StyleKeyType =
   | 'fontFamily'
   | 'CODE'
   | 'STITCH_CALCULATE_ROUND'
+  | 'STITCH_CALCULATE_ROUND_UP'
+  | 'STITCH_CALCULATE_ROUND_DOWN'
   | 'ROW_CALCULATE_ROUND'
   | 'NOT_CALCULATE'
   | 'FONTSIZE';
@@ -30,6 +32,10 @@ type StyleMapType = {
   fontFamily?: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   CODE?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  STITCH_CALCULATE_ROUND_UP?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  STITCH_CALCULATE_ROUND_DOWN?: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   STITCH_CALCULATE_ROUND?: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/plugins/unitDecorator/types.ts
+++ b/src/plugins/unitDecorator/types.ts
@@ -1,3 +1,4 @@
+import { blue } from '@material-ui/core/colors';
 import { deepOrange } from 'themes/colors/deepOrange';
 import { palette } from 'themes/palatte';
 
@@ -6,12 +7,28 @@ export const UnitDecoratorStyleMap = {
     background: palette.action.disabledBackground,
     color: palette.text.primary,
   },
+  STITCH_CALCULATE_ROUND: {
+    background: palette.primary.main,
+    color: palette.background.paper,
+  },
   STITCH_CALCULATE_ROUND_UP: {
     background: deepOrange[900],
     color: palette.background.paper,
   },
   STITCH_CALCULATE_ROUND_DOWN: {
     background: deepOrange[300],
+    color: palette.background.paper,
+  },
+  ROW_CALCULATE_ROUND: {
+    background: palette.secondary.main,
+    color: palette.background.paper,
+  },
+  ROW_CALCULATE_ROUND_UP: {
+    background: blue[900],
+    color: palette.background.paper,
+  },
+  ROW_CALCULATE_ROUND_DOWN: {
+    background: blue[300],
     color: palette.background.paper,
   },
 };

--- a/src/plugins/unitDecorator/types.ts
+++ b/src/plugins/unitDecorator/types.ts
@@ -1,8 +1,17 @@
+import { deepOrange } from 'themes/colors/deepOrange';
 import { palette } from 'themes/palatte';
 
 export const UnitDecoratorStyleMap = {
   NOT_CALCULATE: {
     background: palette.action.disabledBackground,
     color: palette.text.primary,
+  },
+  STITCH_CALCULATE_ROUND_UP: {
+    background: deepOrange[900],
+    color: palette.background.paper,
+  },
+  STITCH_CALCULATE_ROUND_DOWN: {
+    background: deepOrange[300],
+    color: palette.background.paper,
   },
 };

--- a/src/plugins/unitDecorator/unitDecorator.tsx
+++ b/src/plugins/unitDecorator/unitDecorator.tsx
@@ -1,8 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import { Tooltip } from '@material-ui/core';
 import { ContentState, EditorState } from 'draft-js';
-import { changeOriginalStyleToNeweStyle } from 'pages/libs/draftjs-utils/inline';
-import { ReactElement, ReactNode, useEffect } from 'react';
-import styled from 'styled-components';
+import {
+  changeOriginalStyleToNeweStyle,
+  StyleKeyType,
+} from 'pages/libs/draftjs-utils/inline';
+import { ReactElement, ReactNode, useEffect, useState } from 'react';
+import styled, { css } from 'styled-components';
 import { theme } from 'themes';
 import { palette } from 'themes/palatte';
 
@@ -23,6 +27,26 @@ export interface UnitDecoratorProps {
   getEditorState(): EditorState;
 }
 
+interface TooltipMenuProps {
+  isSelectedCalculateKey: boolean;
+}
+
+const APPROXIMATION = {
+  ROUND_DOWN: 'ROUND_DOWN',
+  ROUND: 'ROUND',
+  ROUND_UP: 'ROUND_UP',
+  NOT_CALCULATE: 'NOT_CALCULATE',
+} as const;
+
+const DISPLAY_APPROXIMATION = {
+  ROUND_DOWN: '내림',
+  ROUND: '반올림',
+  ROUND_UP: '올림',
+  NOT_CALCULATE: '계산 안함',
+} as const;
+
+type APPROXIMATION_TYPE = typeof APPROXIMATION[keyof typeof APPROXIMATION];
+
 const DecoratorWrapper = styled.span`
   > span {
     background: ${palette.primary.main};
@@ -38,6 +62,36 @@ const DecoratorWrapper = styled.span`
       box-shadow: ${theme.shadows[4]};
     }
   }
+`;
+
+const ToolTipWrapper = styled.div`
+  display: inline-block;
+  position: relative;
+
+  > div {
+    pointer-events: auto;
+  }
+`;
+
+const TooltipMenuContainer = styled.div`
+  display: flex;
+`;
+
+const TooltipMenu = styled.span<TooltipMenuProps>`
+  padding: ${theme.spacing(0.8)};
+  margin: ${theme.spacing(0.2)};
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${palette.action.hover};
+  }
+
+  ${({ isSelectedCalculateKey }) =>
+    isSelectedCalculateKey &&
+    css`
+      background-color: ${palette.action.selected};
+    `}
 `;
 
 export default function UnitDecorator(props: UnitDecoratorProps): ReactElement {
@@ -57,9 +111,14 @@ export default function UnitDecorator(props: UnitDecoratorProps): ReactElement {
     ...otherProps
   } = props;
 
+  const [showToolbar, setShowToolbar] = useState(false);
+  const [
+    currentCalculateKey,
+    setCurrentCalculateKey,
+  ] = useState<APPROXIMATION_TYPE>('ROUND');
+
   const editorState = getEditorState();
-  const calculateKey =
-    unit === '코' ? 'STITCH_CALCULATE_ROUND' : 'ROW_CALCULATE_ROUND';
+  const calculateKey = unit === '코' ? 'STITCH_CALCULATE' : 'ROW_CALCULATE';
 
   useEffect(() => {
     const selectionState = editorState.getSelection();
@@ -77,13 +136,14 @@ export default function UnitDecorator(props: UnitDecoratorProps): ReactElement {
 
     const decoratorStyle = editorStateWithDecoratorSelection.getCurrentInlineStyle();
     const canCalculate =
-      !decoratorStyle.has('NOT_CALCULATE') && !decoratorStyle.has(calculateKey);
+      !decoratorStyle.has('NOT_CALCULATE') &&
+      !decoratorStyle.some((style) => style?.includes(calculateKey) ?? false);
 
     if (canCalculate) {
       const newEeditorState = changeOriginalStyleToNeweStyle({
         editorState,
         blockKey,
-        originalStyle: calculateKey,
+        originalStyle: `${calculateKey}_ROUND` as StyleKeyType,
         startOffset: start,
         endOffset: end,
       });
@@ -92,26 +152,102 @@ export default function UnitDecorator(props: UnitDecoratorProps): ReactElement {
     }
   }, [editorState]);
 
-  const handleClick = (): void => {
+  const handleClick = (approximation: APPROXIMATION_TYPE): void => {
+    if (approximation === currentCalculateKey) {
+      return;
+    }
+
+    const decoratorStyle = editorState.getCurrentInlineStyle();
+    let originalStyle = `${calculateKey}_ROUND`;
+    const newStyle = (approximation === 'NOT_CALCULATE'
+      ? 'NOT_CALCULATE'
+      : `${calculateKey}_${approximation}`) as StyleKeyType;
+
+    decoratorStyle.forEach((style) => {
+      if (
+        style != null &&
+        (style.includes(calculateKey) || style.includes('NOT_CALCULATE'))
+      ) {
+        originalStyle = style;
+      }
+    });
+
     const newEeditorState = changeOriginalStyleToNeweStyle({
       editorState: getEditorState(),
       blockKey,
-      originalStyle: calculateKey,
-      newStyle: 'NOT_CALCULATE',
+      originalStyle: originalStyle as StyleKeyType,
+      newStyle,
       startOffset: start,
       endOffset: end,
     });
 
     setEditorState(newEeditorState);
+    setShowToolbar(false);
+    setCurrentCalculateKey(approximation);
   };
 
+  useEffect(() => {
+    const handleShowToolbar = (): void => {
+      setShowToolbar(false);
+    };
+
+    const timeoutID = setTimeout(() => {
+      if (showToolbar) {
+        document.addEventListener('click', handleShowToolbar);
+      }
+    }, 0);
+
+    return (): void => {
+      document.removeEventListener('click', handleShowToolbar);
+      clearTimeout(timeoutID);
+    };
+  }, [showToolbar]);
+
+  const renderTooltipMenu = (): React.ReactElement => (
+    <TooltipMenuContainer>
+      {Object.values(DISPLAY_APPROXIMATION).map(
+        (displayApproximatio, index): React.ReactElement => {
+          const menuKey =
+            APPROXIMATION[
+              Object.keys(DISPLAY_APPROXIMATION)[index] as APPROXIMATION_TYPE
+            ];
+
+          return (
+            <TooltipMenu
+              key={menuKey}
+              onClick={(): void => handleClick(menuKey)}
+              isSelectedCalculateKey={currentCalculateKey === menuKey}
+            >
+              {displayApproximatio}
+            </TooltipMenu>
+          );
+        },
+      )}
+    </TooltipMenuContainer>
+  );
+
   return (
-    <DecoratorWrapper
-      {...otherProps}
-      className={className}
-      onClick={handleClick}
-    >
-      {children}
-    </DecoratorWrapper>
+    <ToolTipWrapper>
+      <Tooltip
+        arrow
+        open={showToolbar}
+        placement="top"
+        PopperProps={{
+          disablePortal: true,
+        }}
+        disableFocusListener
+        disableHoverListener
+        disableTouchListener
+        title={renderTooltipMenu()}
+      >
+        <DecoratorWrapper
+          {...otherProps}
+          className={className}
+          onClick={(): void => setShowToolbar(!showToolbar)}
+        >
+          {children}
+        </DecoratorWrapper>
+      </Tooltip>
+    </ToolTipWrapper>
   );
 }

--- a/src/plugins/unitDecorator/unitDecorator.tsx
+++ b/src/plugins/unitDecorator/unitDecorator.tsx
@@ -49,7 +49,6 @@ type APPROXIMATION_TYPE = typeof APPROXIMATION[keyof typeof APPROXIMATION];
 
 const DecoratorWrapper = styled.span`
   > span {
-    background: ${palette.primary.main};
     margin: ${theme.spacing(0, 0.5)};
     padding: ${theme.spacing(0.5, 1)};
     border-radius: ${theme.spacing(0.5)};

--- a/src/themes/overrides.ts
+++ b/src/themes/overrides.ts
@@ -68,5 +68,19 @@ export const { overrides } = createMuiTheme({
         borderTopWidth: 5,
       },
     },
+    MuiTooltip: {
+      tooltip: {
+        color: palette.text.primary,
+        backgroundColor: palette.background.paper,
+        fontSize: 12,
+        boxShadow: defaultTheme.shadows[2],
+      },
+      arrow: {
+        color: palette.background.paper,
+        '&:before': {
+          boxShadow: defaultTheme.shadows[2],
+        },
+      },
+    },
   },
 });

--- a/src/themes/palatte.ts
+++ b/src/themes/palatte.ts
@@ -1,4 +1,5 @@
 import { createMuiTheme } from '@material-ui/core';
+import blue from '@material-ui/core/colors/blue';
 
 import { deepOrange } from './colors/deepOrange';
 
@@ -8,6 +9,11 @@ export const { palette } = createMuiTheme({
       light: deepOrange[200],
       main: deepOrange[600],
       dark: deepOrange[800],
+    },
+    secondary: {
+      light: blue[200],
+      main: blue[600],
+      dark: blue[800],
     },
     action: {
       hover: 'rgba(0, 0, 0, 0.06)',


### PR DESCRIPTION
## PR 제안 사유

<!--
아래 키워드 중 하나를 붙여 이슈를 자동으로 종료할 수 있도록 해주세요.
- Close
- Closes
- Closed
- Fix
- Fixes
- Fixed
- Resolve
- Resolves
- Resolved
-->

Resolve #36

<!--
왜 이 PR을 제안하게 되었는지 간략하게 적어주세요.
이슈 내용만으로 설명이 된다면 생략 가능합니다.
-->

## 주요 변경 기록
- 코랑 단 클릭하면 내림, 올림, 반올림, 계산안함을 선택하는 툴팁이 뜨도록 합니다


- 아래 키들을 추가해주었습니다
STITCH_CALCULATE_ROUND_UP
STITCH_CALCULATE_ROUND_DOWN
ROW_CALCULATE_ROUND_UP
ROW_CALCULATE_ROUND_DOWN
<!--
간단하게라도 적어주세요.
변경된 자세한 내용을 적어주셔도 좋습니다.
-->

## Code review

### Code review 에서 중점적으로 봐야하는 부분

<!-- 생략 가능합니다. -->

## Design review

### Design review 에서 중점적으로 봐야하는 부분 / 스크린샷
<img width="537" alt="스크린샷 2021-05-09 오후 8 32 35" src="https://user-images.githubusercontent.com/26711037/117570591-b2580d80-b105-11eb-806f-c273b813a2af.png">

<!-- 생략 가능합니다. -->

## 기타 질문 및 특이 사항

<!-- 생략 가능합니다. -->
