### PR TITLE
[Feat] 도안 저장 실패 시 스낵바를 띄우도록

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
+    "@material-ui/lab": "^4.0.0-alpha.58",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/src/dumbs/Snackbar/index.tsx
+++ b/src/dumbs/Snackbar/index.tsx
@@ -1,0 +1,38 @@
+import { Snackbar as MaterialSnackbar } from '@material-ui/core';
+import MuiAlert, { Color } from '@material-ui/lab/Alert';
+import React from 'react';
+
+interface Props {
+  autoHideDuration: number;
+  label: string;
+  onClose?(): void;
+  open: boolean;
+  severity: Color;
+}
+
+const Snackbar = ({
+  autoHideDuration,
+  label,
+  onClose,
+  open,
+  severity,
+}: Props): React.ReactElement => {
+  return (
+    <MaterialSnackbar
+      open={open}
+      autoHideDuration={autoHideDuration}
+      onClose={onClose}
+    >
+      <MuiAlert
+        elevation={6}
+        variant="filled"
+        severity={severity}
+        onClose={onClose}
+      >
+        {label}
+      </MuiAlert>
+    </MaterialSnackbar>
+  );
+};
+
+export default Snackbar;

--- a/src/dumbs/Snackbar/index.tsx
+++ b/src/dumbs/Snackbar/index.tsx
@@ -3,7 +3,7 @@ import MuiAlert, { Color } from '@material-ui/lab/Alert';
 import React from 'react';
 
 interface Props {
-  autoHideDuration: number;
+  autoHideDuration?: number;
   label: string;
   onClose?(): void;
   open: boolean;
@@ -11,7 +11,7 @@ interface Props {
 }
 
 const Snackbar = ({
-  autoHideDuration,
+  autoHideDuration = 2000,
   label,
   onClose,
   open,

--- a/src/pages/CreateDesign/components/Footer/index.tsx
+++ b/src/pages/CreateDesign/components/Footer/index.tsx
@@ -1,4 +1,5 @@
 import Button, { SIDE } from 'dumbs/Button';
+import Snackbar from 'dumbs/Snackbar';
 import {
   currentDesignInputAtom,
   currentStepAtom,
@@ -26,6 +27,11 @@ const Footer = (): React.ReactElement => {
     designType,
     patternType,
   } = useRecoilValue(currentDesignInputAtom);
+  const [openErrorSnackbar, setOpenErrorSnackbar] = React.useState(false);
+
+  const handleSnackbarClose = () => {
+    setOpenErrorSnackbar(false);
+  };
 
   const serializeSize = (value: number): Record<string, string | number> => {
     return {
@@ -39,8 +45,7 @@ const Footer = (): React.ReactElement => {
       await requestSaveDesign();
       window.location.reload();
     } catch (e) {
-      // eslint-disable-next-line no-alert
-      alert('도안 저장에 실패했습니다.');
+      setOpenErrorSnackbar(true);
     }
   };
 
@@ -140,6 +145,13 @@ const Footer = (): React.ReactElement => {
         label={renderNextLabel()}
         onClick={handleOnClickNext}
         disabled={disabledNextButton()}
+      />
+      <Snackbar
+        autoHideDuration={2000}
+        label={'도안 저장에 실패했습니다.'}
+        onClose={handleSnackbarClose}
+        open={openErrorSnackbar}
+        severity={'error'}
       />
     </div>
   );

--- a/src/pages/CreateDesign/components/Footer/index.tsx
+++ b/src/pages/CreateDesign/components/Footer/index.tsx
@@ -147,7 +147,6 @@ const Footer = (): React.ReactElement => {
         disabled={disabledNextButton()}
       />
       <Snackbar
-        autoHideDuration={2000}
         label={'도안 저장에 실패했습니다.'}
         onClose={handleSnackbarClose}
         open={openErrorSnackbar}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1843,6 +1843,17 @@
   dependencies:
     "@babel/runtime" "^7.4.4"
 
+"@material-ui/lab@^4.0.0-alpha.58":
+  version "4.0.0-alpha.58"
+  resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-4.0.0-alpha.58.tgz#c7ebb66f49863c5acbb20817163737caa299fafc"
+  integrity sha512-GKHlJqLxUeHH3L3dGQ48ZavYrqGOTXkFkiEiuYMAnAvXAZP4rhMIqeHOPXSUQan4Bd8QnafDcpovOSLnadDmKw==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/utils" "^4.11.2"
+    clsx "^1.0.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.0 || ^17.0.0"
+
 "@material-ui/styles@^4.11.3":
   version "4.11.3"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.3.tgz#1b8d97775a4a643b53478c895e3f2a464e8916f2"


### PR DESCRIPTION
## PR 제안 사유

Close #37

## 주요 변경 기록

- 도안 저장 실패 시 스낵바 띄우도록
  - ![화면-기록-2021-05-15-오후-1 48 50](https://user-images.githubusercontent.com/22957868/118348674-ed839200-b586-11eb-8e48-83e8f46baab5.gif)
- 도안 저장 성공 시 리다이렉트 (일단 다른 화면이 없어서 새로고침)
  - ![화면-기록-2021-05-15-오후-1 54 52](https://user-images.githubusercontent.com/22957868/118348676-f2e0dc80-b586-11eb-9304-9ab0b6400a95.gif)


## Code review

### Code review 에서 중점적으로 봐야하는 부분

<!-- 생략 가능합니다. -->

## Design review

### Design review 에서 중점적으로 봐야하는 부분 / 스크린샷

<!-- 생략 가능합니다. -->

## 기타 질문 및 특이 사항

<!-- 생략 가능합니다. -->
