### PR TITLE
[Fix] 데코레이터가 없어진 경우 키가 사라지지 않는 문제

### DIFF
--- a/src/pages/CreateDesign/Pattern/index.tsx
+++ b/src/pages/CreateDesign/Pattern/index.tsx
@@ -13,6 +13,7 @@ import createToolbarPlugin, {
   Separator,
 } from '@draft-js-plugins/static-toolbar';
 import { DraftStyleMap, EditorState } from 'draft-js';
+import createDeleteDecoratorPlugin from 'plugins/deleteDecorator';
 import createUnitDecoratorPlugin from 'plugins/unitDecorator';
 import { UnitDecoratorStyleMap } from 'plugins/unitDecorator/types';
 import { useRef, useState } from 'react';
@@ -27,6 +28,10 @@ import { getCurrentFontSize } from './utils';
 
 const stitcheDecoratorPlugin = createUnitDecoratorPlugin({ unit: '코' });
 const rowDecoratorPlugin = createUnitDecoratorPlugin({ unit: '단' });
+const deleteDecoratorPlugin = createDeleteDecoratorPlugin({
+  units: ['코', '단'],
+});
+
 const toolbarPlugin = createToolbarPlugin();
 const { Toolbar } = toolbarPlugin;
 
@@ -109,7 +114,12 @@ const Pattern = (): React.ReactElement => {
     return editState;
   };
 
-  const plugins = [stitcheDecoratorPlugin, rowDecoratorPlugin, toolbarPlugin];
+  const plugins = [
+    stitcheDecoratorPlugin,
+    rowDecoratorPlugin,
+    deleteDecoratorPlugin,
+    toolbarPlugin,
+  ];
 
   const focusEditor = (): void => {
     editor?.current?.focus();

--- a/src/pages/libs/draftjs-utils/inline.ts
+++ b/src/pages/libs/draftjs-utils/inline.ts
@@ -241,6 +241,7 @@ interface ChangeOriginalStyleToNewStyle {
   originalStyle: StyleKeyType;
   newStyle?: StyleKeyType;
   blockKey?: string;
+  originalOffset?: number;
   startOffset?: number;
   endOffset?: number;
 }
@@ -250,6 +251,7 @@ export const changeOriginalStyleToNeweStyle = ({
   editorState,
   originalStyle,
   newStyle,
+  originalOffset,
   startOffset,
   endOffset,
 }: ChangeOriginalStyleToNewStyle): EditorState => {
@@ -257,8 +259,8 @@ export const changeOriginalStyleToNeweStyle = ({
   const originalSelection = selectionState.merge({
     anchorKey: selectionState.getAnchorKey(),
     focusKey: selectionState.getFocusKey(),
-    anchorOffset: selectionState.getAnchorOffset(),
-    focusOffset: selectionState.getFocusOffset(),
+    anchorOffset: originalOffset ?? selectionState.getAnchorOffset(),
+    focusOffset: originalOffset ?? selectionState.getFocusOffset(),
   });
 
   const newSelection = selectionState.merge({

--- a/src/plugins/deleteDecorator/deleteDecorator.tsx
+++ b/src/plugins/deleteDecorator/deleteDecorator.tsx
@@ -1,0 +1,73 @@
+import { DraftInlineStyle, EditorState } from 'draft-js';
+import {
+  changeOriginalStyleToNeweStyle,
+  StyleKeyType,
+} from 'pages/libs/draftjs-utils/inline';
+import { ReactElement, useEffect } from 'react';
+
+import { UnitDecoratorProps } from '../unitDecorator';
+
+export default function DeleteDecorator(
+  props: UnitDecoratorProps,
+): ReactElement {
+  const { children, getEditorState, setEditorState, blockKey, end } = props;
+  const editorState = getEditorState();
+
+  const getDecoratorStyle = (startOffset: number): DraftInlineStyle => {
+    const selectionState = editorState.getSelection();
+    const newSelection = selectionState.merge({
+      anchorKey: blockKey,
+      focusKey: blockKey,
+      anchorOffset: startOffset,
+      focusOffset: end,
+    });
+
+    const editorStateWithDecoratorSelection = EditorState.forceSelection(
+      editorState,
+      newSelection,
+    );
+
+    return editorStateWithDecoratorSelection.getCurrentInlineStyle();
+  };
+
+  useEffect(() => {
+    children?.some((element) => {
+      const startOffset = element?.props?.start;
+
+      if (startOffset == null) {
+        return false;
+      }
+
+      const decoratorStyle = getDecoratorStyle(startOffset);
+
+      const canCalculate = decoratorStyle.some(
+        (style) => style?.includes('CALCULATE') ?? false,
+      );
+
+      if (canCalculate) {
+        let newEeditorState;
+
+        decoratorStyle.forEach((style) => {
+          if (style?.includes('CALCULATE')) {
+            newEeditorState = changeOriginalStyleToNeweStyle({
+              editorState,
+              blockKey,
+              originalStyle: style as StyleKeyType,
+              originalOffset: end,
+              startOffset,
+              endOffset: end,
+            });
+          }
+        });
+
+        if (newEeditorState != null) {
+          setEditorState(newEeditorState);
+          return true;
+        }
+      }
+      return false;
+    });
+  }, [editorState]);
+
+  return <>{children}</>;
+}

--- a/src/plugins/deleteDecorator/deleteDecoratorStrategy.ts
+++ b/src/plugins/deleteDecorator/deleteDecoratorStrategy.ts
@@ -1,0 +1,23 @@
+import { ContentBlock } from 'draft-js';
+
+import { extractDeleteDecoratorsWithIndices } from './utils/extractDeleteDecorator';
+
+export default (
+  units: string[],
+  contentBlock: ContentBlock,
+  callback: (begin: number, end: number) => void,
+): void => {
+  const text = contentBlock.getText();
+
+  const results = extractDeleteDecoratorsWithIndices({
+    units,
+    text,
+    contentBlock,
+  });
+
+  results.forEach((unitDecorator) => {
+    const { indices } = unitDecorator;
+
+    callback(indices[0], indices[1]);
+  });
+};

--- a/src/plugins/deleteDecorator/index.tsx
+++ b/src/plugins/deleteDecorator/index.tsx
@@ -1,0 +1,25 @@
+import { EditorPlugin } from '@draft-js-plugins/editor';
+import { ContentBlock } from 'draft-js';
+import deleteDecoratorStrategy from 'plugins/deleteDecorator/deleteDecoratorStrategy';
+
+import DeleteDecorator from '../deleteDecorator/deleteDecorator';
+
+export interface UnitDecoratorPluginConfig {
+  units?: string[];
+}
+
+export default (config: UnitDecoratorPluginConfig = {}): EditorPlugin => {
+  const { units = ['코'] } = config;
+
+  return {
+    decorators: [
+      {
+        strategy: (
+          contentBlock: ContentBlock,
+          callback: (begin: number, end: number) => void,
+        ) => deleteDecoratorStrategy(units, contentBlock, callback),
+        component: DeleteDecorator,
+      },
+    ],
+  };
+};

--- a/src/plugins/deleteDecorator/utils/deleteDecoratorRegex.ts
+++ b/src/plugins/deleteDecorator/utils/deleteDecoratorRegex.ts
@@ -3,6 +3,6 @@ import { numbers } from 'plugins/unitDecorator/utils/unitDecoratorRegex';
 export const getUnitTotallyMatch = (units = '코'): RegExp =>
   new RegExp(`^[${numbers}]+[${units}]`, 'gi');
 
-export const getAllGroupesIntoSpace = (): RegExp =>
+export const getAllGroupsIntoSpace = (): RegExp =>
   // eslint-disable-next-line no-useless-escape
   new RegExp(`(\\S{1,})`, 'g');

--- a/src/plugins/deleteDecorator/utils/deleteDecoratorRegex.ts
+++ b/src/plugins/deleteDecorator/utils/deleteDecoratorRegex.ts
@@ -1,0 +1,8 @@
+import { numbers } from 'plugins/unitDecorator/utils/unitDecoratorRegex';
+
+export const getUnitTotallyMatch = (units = '코'): RegExp =>
+  new RegExp(`^[${numbers}]+[${units}]`, 'gi');
+
+export const getAllGroupesIntoSpace = (): RegExp =>
+  // eslint-disable-next-line no-useless-escape
+  new RegExp(`(\\S{1,})`, 'g');

--- a/src/plugins/deleteDecorator/utils/extractDeleteDecorator.ts
+++ b/src/plugins/deleteDecorator/utils/extractDeleteDecorator.ts
@@ -1,0 +1,91 @@
+import { ContentBlock } from 'draft-js';
+import { getUnitDecoratorBoundary } from 'plugins/unitDecorator/utils/unitDecoratorRegex';
+
+import {
+  getUnitTotallyMatch,
+  getAllGroupesIntoSpace,
+} from './deleteDecoratorRegex';
+
+interface UnitDecoratorIndice {
+  unitDecorator: string;
+  indices: [number, number];
+}
+
+interface Props {
+  units: string[];
+  text: string;
+  contentBlock: ContentBlock;
+}
+
+export function extractDeleteDecoratorsWithIndices({
+  units,
+  text,
+  contentBlock,
+}: Props): UnitDecoratorIndice[] {
+  if (!text) {
+    return [];
+  }
+
+  const tags: UnitDecoratorIndice[] = [];
+  const unitsRegrex = units.join('|');
+
+  function replacer(
+    match: string,
+    _before: string,
+    offset: number,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _chunk: string,
+  ): string {
+    const unitTotallyMatch = match.match(getUnitTotallyMatch(unitsRegrex));
+    const unitProportionMatch = match.match(
+      getUnitDecoratorBoundary(unitsRegrex),
+    );
+
+    if (unitTotallyMatch) {
+      return '';
+    }
+
+    const startPosition = offset;
+    let endPosition = startPosition + match.length;
+    let unitDecorator = match;
+
+    if (unitProportionMatch) {
+      unitDecorator = match.slice(
+        0,
+        match.length - unitProportionMatch[0].length + 1,
+      );
+
+      endPosition = startPosition + unitDecorator.length;
+    }
+
+    let canCalculate = false;
+
+    for (
+      let currentPosition = startPosition;
+      currentPosition < endPosition;
+      currentPosition++
+    ) {
+      const hasCalculatedStyle = contentBlock
+        .getInlineStyleAt(currentPosition)
+        .some((style) => style?.includes('CALCULATE') ?? false);
+
+      if (hasCalculatedStyle) {
+        canCalculate = true;
+        break;
+      }
+    }
+    if (!canCalculate) {
+      return '';
+    }
+
+    tags.push({
+      unitDecorator,
+      indices: [startPosition, endPosition],
+    });
+    return '';
+  }
+
+  text.replace(getAllGroupesIntoSpace(), replacer);
+
+  return tags;
+}

--- a/src/plugins/deleteDecorator/utils/extractDeleteDecorator.ts
+++ b/src/plugins/deleteDecorator/utils/extractDeleteDecorator.ts
@@ -3,7 +3,7 @@ import { getUnitDecoratorBoundary } from 'plugins/unitDecorator/utils/unitDecora
 
 import {
   getUnitTotallyMatch,
-  getAllGroupesIntoSpace,
+  getAllGroupsIntoSpace,
 } from './deleteDecoratorRegex';
 
 interface UnitDecoratorIndice {
@@ -85,7 +85,7 @@ export function extractDeleteDecoratorsWithIndices({
     return '';
   }
 
-  text.replace(getAllGroupesIntoSpace(), replacer);
+  text.replace(getAllGroupsIntoSpace(), replacer);
 
   return tags;
 }

--- a/src/plugins/unitDecorator/unitDecorator.tsx
+++ b/src/plugins/unitDecorator/unitDecorator.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { Tooltip } from '@material-ui/core';
 import { ContentState, EditorState } from 'draft-js';
 import {
@@ -98,12 +97,8 @@ export default function UnitDecorator(props: UnitDecoratorProps): ReactElement {
     className,
     children,
     unit,
-    decoratedText,
-    entityKey,
     getEditorState,
-    offsetKey,
     setEditorState,
-    contentState,
     blockKey,
     start,
     end,

--- a/src/plugins/unitDecorator/unitDecorator.tsx
+++ b/src/plugins/unitDecorator/unitDecorator.tsx
@@ -5,14 +5,14 @@ import {
   changeOriginalStyleToNeweStyle,
   StyleKeyType,
 } from 'pages/libs/draftjs-utils/inline';
-import { ReactElement, ReactNode, useEffect, useState } from 'react';
+import { ReactElement, useEffect, useState } from 'react';
 import styled, { css } from 'styled-components';
 import { theme } from 'themes';
 import { palette } from 'themes/palatte';
 
 export interface UnitDecoratorProps {
   className?: string;
-  children?: ReactNode;
+  children?: ReactElement[];
 
   unit?: string;
   decoratedText?: string;

--- a/src/plugins/unitDecorator/utils/unitDecoratorRegex.ts
+++ b/src/plugins/unitDecorator/utils/unitDecoratorRegex.ts
@@ -1,4 +1,4 @@
-const numbers = '0-9';
+export const numbers = '0-9';
 
 export const getEndHashtagMatch = (unit: string): RegExp =>
   // eslint-disable-next-line no-useless-escape


### PR DESCRIPTION
## PR 제안 사유

<!--
아래 키워드 중 하나를 붙여 이슈를 자동으로 종료할 수 있도록 해주세요.
- Close
- Closes
- Closed
- Fix
- Fixes
- Fixed
- Resolve
- Resolves
- Resolved
-->

Fix #42 

<!--
왜 이 PR을 제안하게 되었는지 간략하게 적어주세요.
이슈 내용만으로 설명이 된다면 생략 가능합니다.
-->

## 주요 변경 기록
111코와 111단이 아닌 경우에 적용되는 deleteDecoratorPlugin을 만들었습니다
#40 을 베이스로 해서 [Add: unit key를 삭제할 때 사용할 정규식 추가](https://github.com/k-roffle/knitting-frontend/pull/43/commits/72eee18c6805322840d6c9a84a6d2c37b4af6584)부터 봐주세여
<!--
간단하게라도 적어주세요.
변경된 자세한 내용을 적어주셔도 좋습니다.
-->

## Code review

### Code review 에서 중점적으로 봐야하는 부분

<!-- 생략 가능합니다. -->

## Design review

### Design review 에서 중점적으로 봐야하는 부분 / 스크린샷
![화면-기록-2021-05-16-오후-11 59 56](https://user-images.githubusercontent.com/26711037/118402044-26b12480-b6a3-11eb-91d1-98149ac236ce.gif)



<!-- 생략 가능합니다. -->

## 기타 질문 및 특이 사항

<!-- 생략 가능합니다. -->
