### PR TITLE
[Feat] Pattern 서버에 저장하기

### DIFF
--- a/src/pages/CreateDesign/Pattern/index.tsx
+++ b/src/pages/CreateDesign/Pattern/index.tsx
@@ -17,11 +17,13 @@ import createDeleteDecoratorPlugin from 'plugins/deleteDecorator';
 import createUnitDecoratorPlugin from 'plugins/unitDecorator';
 import { UnitDecoratorStyleMap } from 'plugins/unitDecorator/types';
 import { useRef, useState } from 'react';
+import { useRecoilState } from 'recoil';
 import styled, { css } from 'styled-components';
 import { theme } from 'themes';
 import { palette } from 'themes/palette';
 
 import { FontSize } from '../components/FontSize';
+import { editorStateAtom } from '../recoils';
 
 import { defaultFontSize } from './types';
 import { getCurrentFontSize } from './utils';
@@ -89,9 +91,7 @@ const ToolbarContentWrapper = styled.div`
 `;
 
 const Pattern = (): React.ReactElement => {
-  const [editorState, setEditorState] = useState<EditorState>(
-    EditorState.createEmpty(),
-  );
+  const [editorState, setEditorState] = useRecoilState(editorStateAtom);
 
   const [customStyleMap, setCustomStyleMap] = useState<DraftStyleMap>({
     CODE: {

--- a/src/pages/CreateDesign/Pattern/index.tsx
+++ b/src/pages/CreateDesign/Pattern/index.tsx
@@ -13,9 +13,9 @@ import createToolbarPlugin, {
   Separator,
 } from '@draft-js-plugins/static-toolbar';
 import { DraftStyleMap, EditorState } from 'draft-js';
+import { customInlineStylesMap } from 'pages/libs/draftjs-utils/inline';
 import createDeleteDecoratorPlugin from 'plugins/deleteDecorator';
 import createUnitDecoratorPlugin from 'plugins/unitDecorator';
-import { UnitDecoratorStyleMap } from 'plugins/unitDecorator/types';
 import { useRef, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import styled, { css } from 'styled-components';
@@ -93,17 +93,9 @@ const ToolbarContentWrapper = styled.div`
 const Pattern = (): React.ReactElement => {
   const [editorState, setEditorState] = useRecoilState(editorStateAtom);
 
-  const [customStyleMap, setCustomStyleMap] = useState<DraftStyleMap>({
-    CODE: {
-      fontFamily: 'monospace',
-      wordWrap: 'break-word',
-      background: palette.grey[300],
-      color: palette.primary.main,
-      borderRadius: theme.spacing(1),
-      padding: theme.spacing(0.3, 0.7),
-    },
-    ...UnitDecoratorStyleMap,
-  });
+  const [customStyleMap, setCustomStyleMap] = useState<DraftStyleMap>(
+    customInlineStylesMap,
+  );
 
   const [currentFontSize, setCurrentFontSize] = useState(
     getCurrentFontSize(editorState, customStyleMap),

--- a/src/pages/CreateDesign/Review/index.tsx
+++ b/src/pages/CreateDesign/Review/index.tsx
@@ -1,10 +1,12 @@
+import Editor from '@draft-js-plugins/editor';
 import { Grid, Typography } from '@material-ui/core';
+import { customInlineStylesMap } from 'pages/libs/draftjs-utils/inline';
 import React from 'react';
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
 import DesignSizeImage from '../components/DesignSizeImage';
-import { currentDesignInputAtom } from '../recoils';
+import { currentDesignInputAtom, editorStateAtom } from '../recoils';
 import { PATTERN, PATTERN_TYPE } from '../types';
 import { formatNumber } from '../utils';
 
@@ -44,6 +46,8 @@ const Review = (): React.ReactElement => {
     designType,
     patternType,
   } = currentDesignInput;
+
+  const editorState = useRecoilValue(editorStateAtom);
 
   const { TEXT, IMAGE, VIDEO } = PATTERN;
 
@@ -135,6 +139,16 @@ const Review = (): React.ReactElement => {
         <Row item xs={12}>
           <Label variant="h4">판매 가격</Label>
           <Contents>{renderPrice(price)}</Contents>
+        </Row>
+        <Row item xs={12}>
+          <Label variant="h4">도안</Label>
+          <Contents>
+            <Editor
+              customStyleMap={customInlineStylesMap}
+              editorState={editorState}
+              readOnly={true}
+            />
+          </Contents>
         </Row>
       </Grid>
     </>

--- a/src/pages/CreateDesign/components/Footer/index.tsx
+++ b/src/pages/CreateDesign/components/Footer/index.tsx
@@ -1,8 +1,10 @@
+import { convertToRaw } from 'draft-js';
 import Button, { SIDE } from 'dumbs/Button';
 import Snackbar from 'dumbs/Snackbar';
 import {
   currentDesignInputAtom,
   currentStepAtom,
+  editorStateAtom,
 } from 'pages/CreateDesign/recoils';
 import { PAGE } from 'pages/CreateDesign/types';
 import React, { useState } from 'react';
@@ -27,6 +29,8 @@ const Footer = (): React.ReactElement => {
     designType,
     patternType,
   } = useRecoilValue(currentDesignInputAtom);
+  const editorState = useRecoilValue(editorStateAtom);
+
   const [openErrorSnackbar, setOpenErrorSnackbar] = useState(false);
 
   const handleSnackbarClose = () => {
@@ -71,9 +75,7 @@ const Footer = (): React.ReactElement => {
       },
       designType,
       patternType,
-      pattern: {
-        value: '',
-      },
+      pattern: convertToRaw(editorState.getCurrentContent()),
     });
   };
 

--- a/src/pages/CreateDesign/components/Footer/index.tsx
+++ b/src/pages/CreateDesign/components/Footer/index.tsx
@@ -5,7 +5,7 @@ import {
   currentStepAtom,
 } from 'pages/CreateDesign/recoils';
 import { PAGE } from 'pages/CreateDesign/types';
-import React from 'react';
+import React, { useState } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { request } from 'utils/requests';
 
@@ -27,7 +27,7 @@ const Footer = (): React.ReactElement => {
     designType,
     patternType,
   } = useRecoilValue(currentDesignInputAtom);
-  const [openErrorSnackbar, setOpenErrorSnackbar] = React.useState(false);
+  const [openErrorSnackbar, setOpenErrorSnackbar] = useState(false);
 
   const handleSnackbarClose = () => {
     setOpenErrorSnackbar(false);

--- a/src/pages/CreateDesign/recoils.ts
+++ b/src/pages/CreateDesign/recoils.ts
@@ -1,3 +1,4 @@
+import { EditorState } from 'draft-js';
 import { atom } from 'recoil';
 
 import { DESIGN, DesignInput, PAGE, PAGE_TYPE, PATTERN } from './types';
@@ -26,4 +27,9 @@ export const currentDesignInputAtom = atom<DesignInput>({
     price: 0,
     pattern: '',
   },
+});
+
+export const editorStateAtom = atom<EditorState>({
+  key: 'editorState',
+  default: EditorState.createEmpty(),
 });

--- a/src/pages/libs/draftjs-utils/inline.ts
+++ b/src/pages/libs/draftjs-utils/inline.ts
@@ -1,4 +1,7 @@
 import { ContentBlock, EditorState, Modifier, RichUtils } from 'draft-js';
+import { UnitDecoratorStyleMap } from 'plugins/unitDecorator/types';
+import { theme } from 'themes';
+import { palette } from 'themes/palette';
 
 import { getSelectedBlocksList } from './block';
 import {
@@ -81,7 +84,15 @@ export const customInlineStylesMap: StyleMapType = {
   bgcolor: {},
   fontSize: {},
   fontFamily: {},
-  CODE: {},
+  CODE: {
+    fontFamily: 'monospace',
+    wordWrap: 'break-word',
+    background: palette.grey[300],
+    color: palette.primary.main,
+    borderRadius: theme.spacing(1),
+    padding: theme.spacing(0.3, 0.7),
+  },
+  ...UnitDecoratorStyleMap,
 };
 
 const getCurrentInlineStyle = (


### PR DESCRIPTION
## PR 제안 사유

<!--
아래 키워드 중 하나를 붙여 이슈를 자동으로 종료할 수 있도록 해주세요.
- Close
- Closes
- Closed
- Fix
- Fixes
- Fixed
- Resolve
- Resolves
- Resolved
-->

Resolve #60 

<!--
왜 이 PR을 제안하게 되었는지 간략하게 적어주세요.
이슈 내용만으로 설명이 된다면 생략 가능합니다.
-->

## 주요 변경 기록
#57 을 베이스로 했습니다! [Refactor: useState import한 React에서 사용하도록 수정](https://github.com/k-roffle/knitting-frontend/pull/61/commits/6b4051d147c4a4363001d1690bfb1119542c3458) 커밋부터 봐주세요!

- Pattern 내용을 Review에서도 확인할 수 있도록 합니다
- Pattern 데이터를 서버에 보내고 있지 않아 서버로 데이터를 보낼 수 있도록 합니다
- 다른 컴포넌트에서도 editorState을 쓸 수 있도록 useState에서 recoil로 변경했습니다
- 서버로 넘겨주기전 convertToRaw를 통해 EditorState를 객체로 변경해주었습니다
<!--
간단하게라도 적어주세요.
변경된 자세한 내용을 적어주셔도 좋습니다.
-->

## Code review

### Code review 에서 중점적으로 봐야하는 부분

<!-- 생략 가능합니다. -->

## Design review

### Design review 에서 중점적으로 봐야하는 부분 / 스크린샷
<img width="1431" alt="스크린샷 2021-06-19 오전 1 45 06" src="https://user-images.githubusercontent.com/26711037/122592995-fc86c400-d09f-11eb-94d3-51fd73c7de7f.png">

<!-- 생략 가능합니다. -->

## 기타 질문 및 특이 사항

<!-- 생략 가능합니다. -->
