### PR TITLE
[Design] 내 정보 페이지에 판매 개수 & 추가하기 버튼 추가 

### DIFF
--- a/src/dumbs/EmptyContent/index.tsx
+++ b/src/dumbs/EmptyContent/index.tsx
@@ -12,7 +12,7 @@ const EmptyContentContainer = styled.div`
   padding: ${theme.spacing(7)};
 `;
 
-const Subtitle = styled(Typography)`
+const Description = styled(Typography)`
   display: block;
   color: ${palette.text.secondary};
   margin-top: ${theme.spacing(1)};
@@ -24,21 +24,23 @@ const CreateButton = styled(Button)`
 
 export interface EmptyContentProps {
   title: string;
-  subtitle?: string;
+  description?: string;
   buttonText: string;
   onClick: () => void;
 }
 
 const EmptyContent = ({
   title,
-  subtitle,
+  description,
   buttonText,
   onClick,
 }: EmptyContentProps): React.ReactElement => {
   return (
     <EmptyContentContainer>
       <Typography variant="h5">{title}</Typography>
-      {subtitle != null && <Subtitle variant="caption">{subtitle}</Subtitle>}
+      {description != null && (
+        <Description variant="caption">{description}</Description>
+      )}
       <CreateButton variant="contained" color="primary" onClick={onClick}>
         {buttonText}
       </CreateButton>

--- a/src/dumbs/EmptyContent/index.tsx
+++ b/src/dumbs/EmptyContent/index.tsx
@@ -1,0 +1,49 @@
+import { Button, Typography } from '@material-ui/core';
+import React from 'react';
+import styled from 'styled-components';
+import { flexCenterAlign } from 'styles/constants';
+import { theme } from 'themes';
+import { palette } from 'themes/palette';
+
+const EmptyContentContainer = styled.div`
+  ${flexCenterAlign}
+
+  flex-direction: column;
+  padding: ${theme.spacing(7)};
+`;
+
+const Subtitle = styled(Typography)`
+  display: block;
+  color: ${palette.text.secondary};
+  margin-top: ${theme.spacing(1)};
+`;
+
+const CreateButton = styled(Button)`
+  margin-top: ${theme.spacing(3)};
+`;
+
+export interface EmptyContentProps {
+  title: string;
+  subtitle?: string;
+  buttonText: string;
+  onClick: () => void;
+}
+
+const EmptyContent = ({
+  title,
+  subtitle,
+  buttonText,
+  onClick,
+}: EmptyContentProps): React.ReactElement => {
+  return (
+    <EmptyContentContainer>
+      <Typography variant="h5">{title}</Typography>
+      {subtitle != null && <Subtitle variant="caption">{subtitle}</Subtitle>}
+      <CreateButton variant="contained" color="primary" onClick={onClick}>
+        {buttonText}
+      </CreateButton>
+    </EmptyContentContainer>
+  );
+};
+
+export default EmptyContent;

--- a/src/pages/MyInformation/components/InformationTabPanel/index.tsx
+++ b/src/pages/MyInformation/components/InformationTabPanel/index.tsx
@@ -1,17 +1,21 @@
-import { DESIGN_MENU_TYPE } from '../InformationTabs';
+import { selectedTabAtom } from 'pages/MyInformation/recoils';
+import { DESIGN_MENU_TYPE } from 'pages/MyInformation/types';
+import { useRecoilValue } from 'recoil';
 
 interface Props {
   children?: React.ReactNode;
-  selectedValue: DESIGN_MENU_TYPE;
   value: DESIGN_MENU_TYPE;
 }
 
-const InformationTabPanel = (props: Props): React.ReactElement => {
-  const { children, value, selectedValue } = props;
+const InformationTabPanel = ({
+  children,
+  value,
+}: Props): React.ReactElement => {
+  const selectedTab = useRecoilValue(selectedTabAtom);
 
   return (
-    <div role="tabpanel" hidden={value !== selectedValue}>
-      {value === selectedValue && <section>{children}</section>}
+    <div role="tabpanel" hidden={value !== selectedTab}>
+      {value === selectedTab && <section>{children}</section>}
     </div>
   );
 };

--- a/src/pages/MyInformation/components/InformationTabs/index.tsx
+++ b/src/pages/MyInformation/components/InformationTabs/index.tsx
@@ -1,6 +1,9 @@
 import { List, Tab, Tabs } from '@material-ui/core';
 import EmptyContent from 'dumbs/EmptyContent';
-import { itemLengthAtom, selectedTabAtom } from 'pages/MyInformation/recoils';
+import {
+  selectedTabAtom,
+  tabItemLengthAtom,
+} from 'pages/MyInformation/recoils';
 import { DESIGN_MENU_TYPE, DESIGN_MENU } from 'pages/MyInformation/types';
 import React, { useEffect } from 'react';
 import { useRecoilState, useSetRecoilState } from 'recoil';
@@ -40,7 +43,7 @@ const StyledList = styled(List)`
 
 const MyInformationTabs = (): React.ReactElement => {
   const [selectedTab, setSelectedTab] = useRecoilState(selectedTabAtom);
-  const setItemLength = useSetRecoilState(itemLengthAtom);
+  const setTabItemLength = useSetRecoilState(tabItemLengthAtom);
 
   const emptyContent = useRenderEmptyContent();
 
@@ -52,7 +55,7 @@ const MyInformationTabs = (): React.ReactElement => {
   };
 
   useEffect(() => {
-    setItemLength(Mock.length);
+    setTabItemLength(Mock.length);
   }, [Mock]);
 
   return (

--- a/src/pages/MyInformation/components/InformationTabs/index.tsx
+++ b/src/pages/MyInformation/components/InformationTabs/index.tsx
@@ -1,5 +1,8 @@
 import { List, Tab, Tabs } from '@material-ui/core';
+import { selectedTabAtom } from 'pages/MyInformation/recoils';
+import { DESIGN_MENU_TYPE, DESIGN_MENU } from 'pages/MyInformation/types';
 import React from 'react';
+import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
 import { theme } from 'themes';
 import { v4 as uuidv4 } from 'uuid';
@@ -28,34 +31,24 @@ const Mock = [
   },
 ];
 
-export const DESIGN_MENU = {
-  CREATED_DESIGN: 'created_design',
-  DESIGN_ON_SALE: 'design_on_sale',
-  PURCHASED_DESIGN: 'purchased_design',
-} as const;
-
-export type DESIGN_MENU_TYPE = typeof DESIGN_MENU[keyof typeof DESIGN_MENU];
-
 const StyledList = styled(List)`
   margin-top: ${theme.spacing(2)};
 `;
 
 const MyInformationTabs = (): React.ReactElement => {
-  const [value, setValue] = React.useState<DESIGN_MENU_TYPE>(
-    DESIGN_MENU.CREATED_DESIGN,
-  );
+  const [selectedTab, setSelectedTab] = useRecoilState(selectedTabAtom);
 
   const handleChange = (
     _event: React.ChangeEvent<Record<string, never>>,
     newValue: DESIGN_MENU_TYPE,
   ) => {
-    setValue(newValue);
+    setSelectedTab(newValue);
   };
 
   return (
     <div>
       <Tabs
-        value={value}
+        value={selectedTab}
         onChange={handleChange}
         textColor="primary"
         indicatorColor="primary"
@@ -72,10 +65,7 @@ const MyInformationTabs = (): React.ReactElement => {
           disabled
         />
       </Tabs>
-      <InformationTabPanel
-        selectedValue={value}
-        value={DESIGN_MENU.CREATED_DESIGN}
-      >
+      <InformationTabPanel value={DESIGN_MENU.CREATED_DESIGN}>
         <StyledList>
           {Mock.map((data, index) => (
             <DesignItem
@@ -86,16 +76,10 @@ const MyInformationTabs = (): React.ReactElement => {
           ))}
         </StyledList>
       </InformationTabPanel>
-      <InformationTabPanel
-        selectedValue={value}
-        value={DESIGN_MENU.DESIGN_ON_SALE}
-      >
+      <InformationTabPanel value={DESIGN_MENU.DESIGN_ON_SALE}>
         판매 중인 도안 리스트
       </InformationTabPanel>
-      <InformationTabPanel
-        selectedValue={value}
-        value={DESIGN_MENU.PURCHASED_DESIGN}
-      >
+      <InformationTabPanel value={DESIGN_MENU.PURCHASED_DESIGN}>
         구매한 도안 리스트
       </InformationTabPanel>
     </div>

--- a/src/pages/MyInformation/components/InformationTabs/index.tsx
+++ b/src/pages/MyInformation/components/InformationTabs/index.tsx
@@ -66,12 +66,12 @@ const MyInformationTabs = (): React.ReactElement => {
         <Tab value={DESIGN_MENU.CREATED_DESIGN} label="내가 만든 도안" />
         <Tab
           value={DESIGN_MENU.DESIGN_ON_SALE}
-          label="판매 중인 도안"
+          label="판매 중인 상품"
           disabled
         />
         <Tab
           value={DESIGN_MENU.PURCHASED_DESIGN}
-          label="구매한 도안"
+          label="구매한 상품"
           disabled
         />
       </Tabs>

--- a/src/pages/MyInformation/components/InformationTabs/index.tsx
+++ b/src/pages/MyInformation/components/InformationTabs/index.tsx
@@ -1,14 +1,17 @@
 import { List, Tab, Tabs } from '@material-ui/core';
-import { selectedTabAtom } from 'pages/MyInformation/recoils';
+import EmptyContent from 'dumbs/EmptyContent';
+import { itemLengthAtom, selectedTabAtom } from 'pages/MyInformation/recoils';
 import { DESIGN_MENU_TYPE, DESIGN_MENU } from 'pages/MyInformation/types';
-import React from 'react';
-import { useRecoilState } from 'recoil';
+import React, { useEffect } from 'react';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import styled from 'styled-components';
 import { theme } from 'themes';
 import { v4 as uuidv4 } from 'uuid';
 
 import DesignItem from '../DesignItem';
 import InformationTabPanel from '../InformationTabPanel';
+
+import { useRenderEmptyContent } from './useRenderEmptyContent';
 
 const Mock = [
   {
@@ -37,6 +40,9 @@ const StyledList = styled(List)`
 
 const MyInformationTabs = (): React.ReactElement => {
   const [selectedTab, setSelectedTab] = useRecoilState(selectedTabAtom);
+  const setItemLength = useSetRecoilState(itemLengthAtom);
+
+  const emptyContent = useRenderEmptyContent();
 
   const handleChange = (
     _event: React.ChangeEvent<Record<string, never>>,
@@ -44,6 +50,10 @@ const MyInformationTabs = (): React.ReactElement => {
   ) => {
     setSelectedTab(newValue);
   };
+
+  useEffect(() => {
+    setItemLength(Mock.length);
+  }, [Mock]);
 
   return (
     <div>
@@ -74,6 +84,9 @@ const MyInformationTabs = (): React.ReactElement => {
               showDivider={Mock.length - 1 !== index}
             />
           ))}
+          {Mock.length === 0 && emptyContent != null && (
+            <EmptyContent {...emptyContent} />
+          )}
         </StyledList>
       </InformationTabPanel>
       <InformationTabPanel value={DESIGN_MENU.DESIGN_ON_SALE}>

--- a/src/pages/MyInformation/components/InformationTabs/useRenderEmptyContent.ts
+++ b/src/pages/MyInformation/components/InformationTabs/useRenderEmptyContent.ts
@@ -20,7 +20,7 @@ export const useRenderEmptyContent = (): EmptyContentProps | null => {
         // TODO: 상품 등록하기 페이지 추가되면 url 변경하기
         return {
           title: '아직 판매 중인 상품이 없어요! 😢',
-          subtitle:
+          description:
             '다른 사람이 도안을 구매하기 위해서는 판매 상품으로 등록해야 해요!',
           buttonText: '지금 상품 판매하기',
           onClick: () => history.push('/my/designs/create'),

--- a/src/pages/MyInformation/components/InformationTabs/useRenderEmptyContent.ts
+++ b/src/pages/MyInformation/components/InformationTabs/useRenderEmptyContent.ts
@@ -1,0 +1,34 @@
+import { EmptyContentProps } from 'dumbs/EmptyContent';
+import { selectedTabAtom } from 'pages/MyInformation/recoils';
+import { DESIGN_MENU } from 'pages/MyInformation/types';
+import { useHistory } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+
+export const useRenderEmptyContent = (): EmptyContentProps | null => {
+  const selectedTab = useRecoilValue(selectedTabAtom);
+  const history = useHistory();
+
+  const getEmptyContent = (): EmptyContentProps | null => {
+    switch (selectedTab) {
+      case DESIGN_MENU.CREATED_DESIGN:
+        return {
+          title: '아직 만든 도안이 없어요! 😢',
+          buttonText: '지금 도안 만들기',
+          onClick: () => history.push('/my/designs/create'),
+        };
+      case DESIGN_MENU.DESIGN_ON_SALE:
+        // TODO: 상품 등록하기 페이지 추가되면 url 변경하기
+        return {
+          title: '아직 판매 중인 상품이 없어요! 😢',
+          subtitle:
+            '다른 사람이 도안을 구매하기 위해서는 판매 상품으로 등록해야 해요!',
+          buttonText: '지금 상품 판매하기',
+          onClick: () => history.push('/my/designs/create'),
+        };
+      default:
+        return null;
+    }
+  };
+
+  return getEmptyContent();
+};

--- a/src/pages/MyInformation/components/MyProfile/index.tsx
+++ b/src/pages/MyInformation/components/MyProfile/index.tsx
@@ -1,5 +1,5 @@
 import { Button, Typography } from '@material-ui/core';
-import { itemLengthAtom } from 'pages/MyInformation/recoils';
+import { tabItemLengthAtom } from 'pages/MyInformation/recoils';
 import React from 'react';
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
@@ -66,14 +66,14 @@ const mock = {
 
 const MyProfile = (): React.ReactElement => {
   const [createButtonText, handleButtonClick] = useRenderButtonText();
-  const itemLength = useRecoilValue(itemLengthAtom);
+  const tabItemLength = useRecoilValue(tabItemLengthAtom);
 
   const {
     number_of_designs_on_sales: numberOfDesignsOnSales,
     number_of_designs_sold: numberOfDesignsSold,
   } = mock;
 
-  const emptyList = itemLength === 0;
+  const emptyList = tabItemLength === 0;
 
   return (
     <MyProfileContainer>

--- a/src/pages/MyInformation/components/MyProfile/index.tsx
+++ b/src/pages/MyInformation/components/MyProfile/index.tsx
@@ -1,4 +1,4 @@
-import { Typography } from '@material-ui/core';
+import { Button, Typography } from '@material-ui/core';
 import React from 'react';
 import styled from 'styled-components';
 import { flexVerticalAlign } from 'styles/constants';
@@ -6,17 +6,25 @@ import { theme } from 'themes';
 import { palette } from 'themes/palette';
 
 const MyProfileContainer = styled.section`
+  display: inline-block;
+  width: 100%;
+  margin-bottom: ${theme.spacing(6)};
+`;
+
+const ProfileContainer = styled.div`
   ${flexVerticalAlign};
+
   display: flex;
-  margin-bottom: ${theme.spacing(8)};
+  float: left;
+  margin-right: ${theme.spacing(3)};
 `;
 
 const EmptyProfile = styled.span`
   display: inline-block;
-  width: ${theme.spacing(8)};
-  height: ${theme.spacing(8)};
-  border-radius: ${theme.spacing(4)};
-  margin-right: ${theme.spacing(2)};
+  min-width: ${theme.spacing(10)};
+  min-height: ${theme.spacing(10)};
+  border-radius: ${theme.spacing(5)};
+  margin-right: ${theme.spacing(3)};
   background-color: ${palette.grey[300]};
 `;
 
@@ -29,14 +37,49 @@ const Email = styled.span`
   color: ${palette.text.secondary};
 `;
 
+const MySalesSummary = styled.div`
+  display: flex;
+  margin-top: ${theme.spacing(1.5)};
+
+  > div:first-child {
+    margin-right: ${theme.spacing(3)};
+  }
+`;
+
+const SalesSummaryCount = styled(Typography)`
+  text-align: center;
+`;
+
+const CreateButton = styled(Button)`
+  float: right;
+  margin-top: ${theme.spacing((10 - 4.5) / 2)};
+`;
+
 const MyProfile = (): React.ReactElement => {
   return (
     <MyProfileContainer>
-      <EmptyProfile />
-      <div>
-        <Name variant="h5">홍길동</Name>
-        <Email>red.road@gmail.com</Email>
-      </div>
+      <ProfileContainer>
+        <EmptyProfile />
+        <div>
+          <div>
+            <Name variant="h5">홍길동</Name>
+            <Email>red.road@gmail.com</Email>
+          </div>
+          <MySalesSummary>
+            <div>
+              <Typography variant="caption">판매중인 상품</Typography>
+              <SalesSummaryCount variant="h5">2</SalesSummaryCount>
+            </div>
+            <div>
+              <Typography variant="caption">판매 수</Typography>
+              <SalesSummaryCount variant="h5">18</SalesSummaryCount>
+            </div>
+          </MySalesSummary>
+        </div>
+      </ProfileContainer>
+      <CreateButton variant="outlined" color="primary">
+        새로운 도안 만들기
+      </CreateButton>
     </MyProfileContainer>
   );
 };

--- a/src/pages/MyInformation/components/MyProfile/index.tsx
+++ b/src/pages/MyInformation/components/MyProfile/index.tsx
@@ -1,5 +1,7 @@
 import { Button, Typography } from '@material-ui/core';
+import { itemLengthAtom } from 'pages/MyInformation/recoils';
 import React from 'react';
+import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 import { flexVerticalAlign } from 'styles/constants';
 import { theme } from 'themes';
@@ -57,8 +59,21 @@ const CreateButton = styled(Button)`
   margin-top: ${theme.spacing((10 - 4.5) / 2)};
 `;
 
+const mock = {
+  number_of_designs_on_sales: 2,
+  number_of_designs_sold: 18,
+};
+
 const MyProfile = (): React.ReactElement => {
-  const [createdButtonText, handleButtonClick] = useRenderButtonText();
+  const [createButtonText, handleButtonClick] = useRenderButtonText();
+  const itemLength = useRecoilValue(itemLengthAtom);
+
+  const {
+    number_of_designs_on_sales: numberOfDesignsOnSales,
+    number_of_designs_sold: numberOfDesignsSold,
+  } = mock;
+
+  const emptyList = itemLength === 0;
 
   return (
     <MyProfileContainer>
@@ -72,22 +87,26 @@ const MyProfile = (): React.ReactElement => {
           <MySalesSummary>
             <div>
               <Typography variant="caption">판매중인 상품</Typography>
-              <SalesSummaryCount variant="h5">2</SalesSummaryCount>
+              <SalesSummaryCount variant="h5">
+                {numberOfDesignsOnSales}
+              </SalesSummaryCount>
             </div>
             <div>
               <Typography variant="caption">판매 수</Typography>
-              <SalesSummaryCount variant="h5">18</SalesSummaryCount>
+              <SalesSummaryCount variant="h5">
+                {numberOfDesignsSold}
+              </SalesSummaryCount>
             </div>
           </MySalesSummary>
         </div>
       </ProfileContainer>
-      {createdButtonText != null && handleButtonClick != null && (
+      {createButtonText != null && handleButtonClick != null && !emptyList && (
         <CreateButton
           variant="outlined"
           color="primary"
           onClick={handleButtonClick}
         >
-          {createdButtonText}
+          {createButtonText}
         </CreateButton>
       )}
     </MyProfileContainer>

--- a/src/pages/MyInformation/components/MyProfile/index.tsx
+++ b/src/pages/MyInformation/components/MyProfile/index.tsx
@@ -5,6 +5,8 @@ import { flexVerticalAlign } from 'styles/constants';
 import { theme } from 'themes';
 import { palette } from 'themes/palette';
 
+import { useRenderButtonText } from './useRenderButtonText';
+
 const MyProfileContainer = styled.section`
   display: inline-block;
   width: 100%;
@@ -56,6 +58,8 @@ const CreateButton = styled(Button)`
 `;
 
 const MyProfile = (): React.ReactElement => {
+  const [createdButtonText, handleButtonClick] = useRenderButtonText();
+
   return (
     <MyProfileContainer>
       <ProfileContainer>
@@ -77,9 +81,15 @@ const MyProfile = (): React.ReactElement => {
           </MySalesSummary>
         </div>
       </ProfileContainer>
-      <CreateButton variant="outlined" color="primary">
-        새로운 도안 만들기
-      </CreateButton>
+      {createdButtonText != null && handleButtonClick != null && (
+        <CreateButton
+          variant="outlined"
+          color="primary"
+          onClick={handleButtonClick}
+        >
+          {createdButtonText}
+        </CreateButton>
+      )}
     </MyProfileContainer>
   );
 };

--- a/src/pages/MyInformation/components/MyProfile/useRenderButtonText.ts
+++ b/src/pages/MyInformation/components/MyProfile/useRenderButtonText.ts
@@ -1,0 +1,29 @@
+import { selectedTabAtom } from 'pages/MyInformation/recoils';
+import { DESIGN_MENU } from 'pages/MyInformation/types';
+import { useHistory } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+
+export const useRenderButtonText = (): [
+  text: string | null,
+  clickAction: (() => void) | null,
+] => {
+  const selectedTab = useRecoilValue(selectedTabAtom);
+  const history = useHistory();
+
+  const getButtonText = (): [
+    text: string | null,
+    clickAction: (() => void) | null,
+  ] => {
+    switch (selectedTab) {
+      case DESIGN_MENU.CREATED_DESIGN:
+        return ['새로운 도안 만들기', () => history.push('/my/designs/create')];
+      case DESIGN_MENU.DESIGN_ON_SALE:
+        // TODO: 상품 등록하기 페이지 추가되면 url 변경하기
+        return ['판매 상품 등록하기', () => history.push('/my/designs/create')];
+      default:
+        return [null, null];
+    }
+  };
+
+  return getButtonText();
+};

--- a/src/pages/MyInformation/recoils.ts
+++ b/src/pages/MyInformation/recoils.ts
@@ -6,3 +6,8 @@ export const selectedTabAtom = atom<DESIGN_MENU_TYPE>({
   key: 'selectedTab',
   default: DESIGN_MENU.CREATED_DESIGN,
 });
+
+export const itemLengthAtom = atom<number>({
+  key: 'itemLength',
+  default: 0,
+});

--- a/src/pages/MyInformation/recoils.ts
+++ b/src/pages/MyInformation/recoils.ts
@@ -1,0 +1,8 @@
+import { atom } from 'recoil';
+
+import { DESIGN_MENU, DESIGN_MENU_TYPE } from './types';
+
+export const selectedTabAtom = atom<DESIGN_MENU_TYPE>({
+  key: 'selectedTab',
+  default: DESIGN_MENU.CREATED_DESIGN,
+});

--- a/src/pages/MyInformation/recoils.ts
+++ b/src/pages/MyInformation/recoils.ts
@@ -7,7 +7,7 @@ export const selectedTabAtom = atom<DESIGN_MENU_TYPE>({
   default: DESIGN_MENU.CREATED_DESIGN,
 });
 
-export const itemLengthAtom = atom<number>({
-  key: 'itemLength',
+export const tabItemLengthAtom = atom<number>({
+  key: 'tebItemLength',
   default: 0,
 });

--- a/src/pages/MyInformation/types.ts
+++ b/src/pages/MyInformation/types.ts
@@ -1,0 +1,7 @@
+export const DESIGN_MENU = {
+  CREATED_DESIGN: 'created_design',
+  DESIGN_ON_SALE: 'design_on_sale',
+  PURCHASED_DESIGN: 'purchased_design',
+} as const;
+
+export type DESIGN_MENU_TYPE = typeof DESIGN_MENU[keyof typeof DESIGN_MENU];


### PR DESCRIPTION
## PR 제안 사유

<!--
아래 키워드 중 하나를 붙여 이슈를 자동으로 종료할 수 있도록 해주세요.
- Close
- Closes
- Closed
- Fix
- Fixes
- Fixed
- Resolve
- Resolves
- Resolved
-->

Resolve #84 
<!--
왜 이 PR을 제안하게 되었는지 간략하게 적어주세요.
이슈 내용만으로 설명이 된다면 생략 가능합니다.
-->

## 주요 변경 기록
- 새로운 도안 만들기 버튼 추가 & SalesSummary 껍데기 추가
- 리스트가 여부에 따라 버튼 달라지도록 수정 (리스트가 없으면 탭 내용에 추가할 수 있는 버튼이 나타나도록, 리스트가 있으면 내 정보 상단에 추가할 수 있는 버튼이 나타나도록)
- 내 정보에서 도안 → 상품으로 변경된 워딩 적용
- 선택된 탭 recoil로 변경
<!--
간단하게라도 적어주세요.
변경된 자세한 내용을 적어주셔도 좋습니다.
-->

## Code review

### Code review 에서 중점적으로 봐야하는 부분

<!-- 생략 가능합니다. -->

## Design review

### Design review 에서 중점적으로 봐야하는 부분 / 스크린샷
<img width="1680" alt="스크린샷 2021-08-15 오후 7 04 27" src="https://user-images.githubusercontent.com/26711037/129475796-225168fd-175b-42a5-9616-f903edfdcb75.png">
<img width="1680" alt="스크린샷 2021-08-15 오후 7 05 29" src="https://user-images.githubusercontent.com/26711037/129475798-81c9b7d7-18de-4a43-b837-5ea0e3cf9c23.png">
<img width="1680" alt="스크린샷 2021-08-15 오후 7 30 42" src="https://user-images.githubusercontent.com/26711037/129475799-c2b91656-2560-475f-bb6a-8359daa1bff5.png">

<!-- 생략 가능합니다. -->

## 기타 질문 및 특이 사항

<!-- 생략 가능합니다. -->
