### PR TITLE
[Feat] 도안 리스트 더 불러오기로 데이터 불러올 수 있도록 수정 

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-ellipsis-component": "^1.0.1",
+    "react-infinite-scroll-component": "^6.1.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
     "recoil": "^0.1.2",

--- a/src/pages/MyInformation/components/DesignItem/index.tsx
+++ b/src/pages/MyInformation/components/DesignItem/index.tsx
@@ -114,7 +114,9 @@ const DesignItem = ({
           </Information>
           {createdAt != null && (
             <CreatedDate variant="caption">
-              {isLoading ? <Skeleton variant="text" /> : formatDate(createdAt)}
+              <Skeleton isLoading={isLoading} variant="text">
+                {formatDate(createdAt)}
+              </Skeleton>
             </CreatedDate>
           )}
 

--- a/src/pages/MyInformation/components/Designs/index.tsx
+++ b/src/pages/MyInformation/components/Designs/index.tsx
@@ -1,21 +1,23 @@
 import { FAILED_TO_GET_MY_DESIGNS } from 'constants/errors';
 
-import { List } from '@material-ui/core';
+import { List, Typography } from '@material-ui/core';
 import { useCommonSnackbar } from 'components/CommonSnackbar/useCommonSnackbar';
 import EmptyContent from 'dumbs/EmptyContent';
 import { useGetMyDesigns } from 'pages/MyInformation/hooks/useGetMyDesigns';
 import { tabItemLengthAtom } from 'pages/MyInformation/recoils';
 import { useEffect } from 'react';
+import InfiniteScroll from 'react-infinite-scroll-component';
 import { useSetRecoilState } from 'recoil';
 import styled from 'styled-components';
 import { theme } from 'themes';
 import { DEFAULT_LIST_LENGTH } from 'utils/requestType';
 
+import { DesignItemResponse } from '../../hooks/types';
 import DesignItem from '../DesignItem';
 import { useRenderEmptyContent } from '../InformationTabs/useRenderEmptyContent';
 
 const Designs = (): React.ReactElement => {
-  const { data, error } = useGetMyDesigns();
+  const { data, error, size, setSize } = useGetMyDesigns();
   const setTabItemLength = useSetRecoilState(tabItemLengthAtom);
   const emptyContent = useRenderEmptyContent();
 
@@ -25,26 +27,54 @@ const Designs = (): React.ReactElement => {
     dependencies: [error],
   });
 
-  const designs = data?.payload ?? [];
+  const getResponseDesigns = () =>
+    data?.reduce(
+      (designs: DesignItemResponse[], { payload }) => designs.concat(payload),
+      [],
+    );
   const isLoading = data == null;
+  const designs = isLoading
+    ? [...Array(DEFAULT_LIST_LENGTH)]
+    : getResponseDesigns() ?? [];
   const isEmpty = !isLoading && designs.length === 0;
+  const lastData = data?.[data.length - 1];
+  const hasLastCursor =
+    (lastData?.payload ?? []).length > 0 && lastData?.meta.last_cursor != null;
 
   useEffect(() => {
     setTabItemLength(designs.length);
   }, [designs]);
 
+  const getNextDesigns = (): void => {
+    if (hasLastCursor) {
+      setSize(size + 1);
+    }
+  };
+
   return (
     <StyledList>
-      {(isLoading ? [...Array(DEFAULT_LIST_LENGTH)] : designs).map(
-        (design, index) => (
-          <DesignItem
-            isLoading={data == null}
-            key={isLoading ? index : design.id}
-            {...design}
-            showDivider={designs.length - 1 !== index}
-          />
-        ),
-      )}
+      <InfiniteScroll
+        dataLength={designs.length}
+        next={getNextDesigns}
+        hasMore={hasLastCursor}
+        loader={
+          <Loader>
+            <Typography variant="h5">도안 더 가져오는 중 🏃‍♂️</Typography>
+          </Loader>
+        }
+      >
+        {(isLoading ? [...Array(DEFAULT_LIST_LENGTH)] : designs).map(
+          (design, index) => (
+            <DesignItem
+              isLoading={data == null}
+              id={index}
+              key={isLoading ? index : design.id}
+              {...design}
+              showDivider={designs.length - 1 !== index}
+            />
+          ),
+        )}
+      </InfiniteScroll>
       {isEmpty && emptyContent != null && <EmptyContent {...emptyContent} />}
     </StyledList>
   );
@@ -54,4 +84,10 @@ export default Designs;
 
 const StyledList = styled(List)`
   margin-top: ${theme.spacing(2)};
+`;
+
+const Loader = styled.div`
+  width: 100%;
+  text-align: center;
+  padding: ${theme.spacing(7, 0)};
 `;

--- a/src/pages/MyInformation/components/Designs/index.tsx
+++ b/src/pages/MyInformation/components/Designs/index.tsx
@@ -64,14 +64,18 @@ const Designs = (): React.ReactElement => {
         }
       >
         {(isLoading ? [...Array(DEFAULT_LIST_LENGTH)] : designs).map(
-          (design, index) => (
-            <DesignItem
-              isLoading={data == null}
-              key={index}
-              {...design}
-              showDivider={designs.length - 1 !== index}
-            />
-          ),
+          (design, index) => {
+            const showDivider = designs.length - 1 !== index;
+
+            return (
+              <DesignItem
+                isLoading={data == null}
+                key={index}
+                {...design}
+                showDivider={showDivider}
+              />
+            );
+          },
         )}
       </InfiniteScroll>
       {isEmpty && emptyContent != null && <EmptyContent {...emptyContent} />}

--- a/src/pages/MyInformation/components/Designs/index.tsx
+++ b/src/pages/MyInformation/components/Designs/index.tsx
@@ -67,8 +67,7 @@ const Designs = (): React.ReactElement => {
           (design, index) => (
             <DesignItem
               isLoading={data == null}
-              id={index}
-              key={isLoading ? index : design.id}
+              key={index}
               {...design}
               showDivider={designs.length - 1 !== index}
             />

--- a/src/pages/MyInformation/hooks/useGetMyDesigns.ts
+++ b/src/pages/MyInformation/hooks/useGetMyDesigns.ts
@@ -33,8 +33,12 @@ export const useGetMyDesigns = (): SWRInfiniteResponse<
 
     const isFirstCursor = pageIndex === 0;
     const lastCursor = previousPageData?.meta?.last_cursor;
-    const afterValue =
-      isFirstCursor || lastCursor == null ? `` : `&after=${lastCursor}`;
+
+    let afterValue = '';
+
+    if (!isFirstCursor && lastCursor != null) {
+      afterValue = `&after=${lastCursor}`;
+    }
 
     return `designs/my?count=${DEFAULT_LIST_LENGTH}${afterValue}`;
   }

--- a/src/pages/MyInformation/hooks/useGetMyDesigns.ts
+++ b/src/pages/MyInformation/hooks/useGetMyDesigns.ts
@@ -1,4 +1,4 @@
-import useSWR, { SWRResponse } from 'swr';
+import { SWRInfiniteResponse, useSWRInfinite } from 'swr';
 import { getAccessToken } from 'utils/auth';
 import { DEFAULT_LIST_LENGTH, ListResponse } from 'utils/requestType';
 import { request } from 'utils/requests';
@@ -11,17 +11,37 @@ const getMyDesigns = async (pathname: string): Promise<VendorQueryResult> => {
   const { data } = await request({
     pathname,
     method: 'get',
-    params: {
-      count: DEFAULT_LIST_LENGTH,
-    },
     accessToken: getAccessToken(),
   });
 
   return data;
 };
 
-export const useGetMyDesigns = (): SWRResponse<VendorQueryResult, unknown> => {
-  const response = useSWR('designs/my', (pathname) => getMyDesigns(pathname));
+export const useGetMyDesigns = (): SWRInfiniteResponse<
+  VendorQueryResult,
+  ListResponse<DesignItemResponse>
+> => {
+  function getKey(
+    pageIndex: number,
+    previousPageData: VendorQueryResult | null,
+  ) {
+    const isLastCursor = previousPageData && !previousPageData.payload;
+
+    if (isLastCursor) {
+      return null;
+    }
+
+    const isFirstCursor = pageIndex === 0;
+    const lastCursor = previousPageData?.meta?.last_cursor;
+    const afterValue =
+      isFirstCursor || lastCursor == null ? `` : `&after=${lastCursor}`;
+
+    return `designs/my?count=${DEFAULT_LIST_LENGTH}${afterValue}`;
+  }
+
+  const response = useSWRInfinite(getKey, (pathname: string) =>
+    getMyDesigns(pathname),
+  );
 
   return response;
 };

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -15,8 +15,10 @@ const refreshAccessToken = async (token: string): Promise<void> => {
     accessToken: token,
   })
     .then(({ status, data }) => {
-      if (status === 200) {
-        setAccessToken(data.payload.token);
+      const newToken = data.payload.token;
+
+      if (status === 200 && newToken != null) {
+        setAccessToken(newToken);
       }
     })
     .catch(() => deleteAccessToken());
@@ -26,7 +28,7 @@ export const getAccessToken = (): string | undefined => {
   const now = new Date().getTime() / 1000;
   const token = window.localStorage.getItem('token');
 
-  if (token == null || token === 'undefined') {
+  if (token == null) {
     return undefined;
   }
   const tokenPayload: TokenPayload = decodeJwtToken(token);

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -26,7 +26,7 @@ export const getAccessToken = (): string | undefined => {
   const now = new Date().getTime() / 1000;
   const token = window.localStorage.getItem('token');
 
-  if (token == null) {
+  if (token == null || token === 'undefined') {
     return undefined;
   }
   const tokenPayload: TokenPayload = decodeJwtToken(token);

--- a/yarn.lock
+++ b/yarn.lock
@@ -12363,6 +12363,13 @@ react-hotkeys@2.0.0:
   dependencies:
     prop-types "^15.6.1"
 
+react-infinite-scroll-component@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-infinite-scroll-component/-/react-infinite-scroll-component-6.1.0.tgz#7e511e7aa0f728ac3e51f64a38a6079ac522407f"
+  integrity sha512-SQu5nCqy8DxQWpnUVLx7V7b7LcA37aM7tvoWjTLZp1dk6EJibM5/4EJKzOnl07/BsM1Y40sKLuqjCwwH/xV0TQ==
+  dependencies:
+    throttle-debounce "^2.1.0"
+
 react-input-autosize@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-3.0.0.tgz#6b5898c790d4478d69420b55441fcc31d5c50a85"


### PR DESCRIPTION
## PR 제안 사유

<!--
아래 키워드 중 하나를 붙여 이슈를 자동으로 종료할 수 있도록 해주세요.
- Close
- Closes
- Closed
- Fix
- Fixes
- Fixed
- Resolve
- Resolves
- Resolved
-->

Resolve #93 
<!--
왜 이 PR을 제안하게 되었는지 간략하게 적어주세요.
이슈 내용만으로 설명이 된다면 생략 가능합니다.
-->

## 주요 변경 기록
지금 10개만 불러오는데 last_cursor에 after를 넘겨줘서 데이터를 더 불러올 수 있도록 합니다
패키지는 https://github.com/ankeetmaini/react-infinite-scroll-component 을 사용합니다
<!--
간단하게라도 적어주세요.
변경된 자세한 내용을 적어주셔도 좋습니다.
-->

## Code review

### Code review 에서 중점적으로 봐야하는 부분

<!-- 생략 가능합니다. -->

## Design review

### Design review 에서 중점적으로 봐야하는 부분 / 스크린샷
![화면-기록-2021-08-21-오후-11 17 21](https://user-images.githubusercontent.com/26711037/130324757-5e99081b-eeb1-40ec-a984-e9a1f9f6a2a3.gif)

<!-- 생략 가능합니다. -->

## 기타 질문 및 특이 사항

<!-- 생략 가능합니다. -->
