### PR TITLE
Feat: 내 상품 요약 API 연동

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "dependencies": {
     "@date-io/date-fns": "1.3.13",
-    "@material-ui/core": "^4.11.3",
+    "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
-    "@material-ui/lab": "^4.0.0-alpha.58",
+    "@material-ui/lab": "^4.0.0-alpha.60",
     "@material-ui/pickers": "^3.3.10",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -8,6 +8,8 @@ export const FAILED_TO_FETCH_ACCESS_TOKEN =
   '로그인에 실패하였습니다. 잠시 후 다시 시도해주세요.';
 export const FAILED_TO_GET_MY_DESIGNS =
   '내가 만든 도안 목록을 불러오는데 실패했습니다.';
+export const FAILED_TO_GET_MY_SALE_SUMMARY =
+  '내 상품 요약 정보를 불러오는데 실패했습니다.';
 export const FAILED_TO_SAVE_PRODUCT = '상품 저장에 실패했습니다.';
 export const ONLY_UPLOAD_FILES_BELOW_10MB =
   '10MB 이하에 파일만 업로드할 수 있습니다';

--- a/src/pages/MyInformation/components/MyProfile/index.tsx
+++ b/src/pages/MyInformation/components/MyProfile/index.tsx
@@ -2,6 +2,7 @@ import { FAILED_TO_GET_MY_SALE_SUMMARY } from 'constants/errors';
 
 import { Button, Typography } from '@material-ui/core';
 import { useCommonSnackbar } from 'components/CommonSnackbar/useCommonSnackbar';
+import { useGetMySalesSummary } from 'pages/MyInformation/hooks/useGetMySalesSummary';
 import { tabItemLengthAtom } from 'pages/MyInformation/recoils';
 import React from 'react';
 import { useRecoilValue } from 'recoil';
@@ -9,8 +10,6 @@ import styled from 'styled-components';
 import { flexVerticalAlign } from 'styles/constants';
 import { theme } from 'themes';
 import { palette } from 'themes/palette';
-
-import { useGetMySalesSummary } from '../../hooks/useGetMySalesSummary';
 
 import { useRenderButtonText } from './useRenderButtonText';
 

--- a/src/pages/MyInformation/components/MyProfile/index.tsx
+++ b/src/pages/MyInformation/components/MyProfile/index.tsx
@@ -1,4 +1,7 @@
+import { FAILED_TO_GET_MY_SALE_SUMMARY } from 'constants/errors';
+
 import { Button, Typography } from '@material-ui/core';
+import { useCommonSnackbar } from 'components/CommonSnackbar/useCommonSnackbar';
 import { tabItemLengthAtom } from 'pages/MyInformation/recoils';
 import React from 'react';
 import { useRecoilValue } from 'recoil';
@@ -6,6 +9,8 @@ import styled from 'styled-components';
 import { flexVerticalAlign } from 'styles/constants';
 import { theme } from 'themes';
 import { palette } from 'themes/palette';
+
+import { useGetMySalesSummary } from '../../hooks/useGetMySalesSummary';
 
 import { useRenderButtonText } from './useRenderButtonText';
 
@@ -59,20 +64,25 @@ const CreateButton = styled(Button)`
   margin-top: ${theme.spacing((10 - 4.5) / 2)};
 `;
 
-const mock = {
-  number_of_designs_on_sales: 2,
-  number_of_designs_sold: 18,
-};
-
 const MyProfile = (): React.ReactElement => {
   const [createButtonText, handleButtonClick] = useRenderButtonText();
   const tabItemLength = useRecoilValue(tabItemLengthAtom);
+  const { data, error } = useGetMySalesSummary();
 
+  useCommonSnackbar({
+    message: FAILED_TO_GET_MY_SALE_SUMMARY,
+    severity: 'error',
+    dependencies: [error],
+  });
+
+  const isLoading = data == null;
   const {
-    number_of_designs_on_sales: numberOfDesignsOnSales,
-    number_of_designs_sold: numberOfDesignsSold,
-  } = mock;
-
+    number_of_products_on_sales: numberOfProductsOnSales,
+    number_of_products_sold: numberOfProductsSold,
+  } = data?.payload ?? {
+    number_of_products_on_sales: 0,
+    number_of_products_sold: 0,
+  };
   const emptyList = tabItemLength === 0;
 
   return (
@@ -88,13 +98,13 @@ const MyProfile = (): React.ReactElement => {
             <div>
               <Typography variant="caption">판매중인 상품</Typography>
               <SalesSummaryCount variant="h5">
-                {numberOfDesignsOnSales}
+                {numberOfProductsOnSales}
               </SalesSummaryCount>
             </div>
             <div>
               <Typography variant="caption">판매 수</Typography>
               <SalesSummaryCount variant="h5">
-                {numberOfDesignsSold}
+                {numberOfProductsSold}
               </SalesSummaryCount>
             </div>
           </MySalesSummary>

--- a/src/pages/MyInformation/hooks/types.ts
+++ b/src/pages/MyInformation/hooks/types.ts
@@ -6,3 +6,8 @@ export type DesignItemResponse = {
   tags: string[];
   created_at: string;
 };
+
+export type SalesSummeryResponse = {
+  number_of_products_on_sales: number;
+  number_of_products_sold: number;
+};

--- a/src/pages/MyInformation/hooks/types.ts
+++ b/src/pages/MyInformation/hooks/types.ts
@@ -7,7 +7,7 @@ export type DesignItemResponse = {
   created_at: string;
 };
 
-export type SalesSummeryResponse = {
+export type SalesSummaryResponse = {
   number_of_products_on_sales: number;
   number_of_products_sold: number;
 };

--- a/src/pages/MyInformation/hooks/useGetMySalesSummary.ts
+++ b/src/pages/MyInformation/hooks/useGetMySalesSummary.ts
@@ -1,0 +1,29 @@
+import useSWR, { SWRResponse } from 'swr';
+import { getAccessToken } from 'utils/auth';
+import { SingleResponse } from 'utils/requestType';
+import { request } from 'utils/requests';
+
+import { SalesSummeryResponse } from './types';
+
+type VendorQueryResult = SingleResponse<SalesSummeryResponse>;
+
+const getMySalesSummary = async (
+  pathname: string,
+): Promise<VendorQueryResult> => {
+  const { data } = await request({
+    pathname,
+    method: 'get',
+    accessToken: getAccessToken(),
+  });
+
+  return data;
+};
+
+export const useGetMySalesSummary = (): SWRResponse<
+  VendorQueryResult,
+  SingleResponse<SalesSummeryResponse>
+> => {
+  const response = useSWR('/me/sales-summary', getMySalesSummary);
+
+  return response;
+};

--- a/src/pages/MyInformation/hooks/useGetMySalesSummary.ts
+++ b/src/pages/MyInformation/hooks/useGetMySalesSummary.ts
@@ -3,13 +3,13 @@ import { getAccessToken } from 'utils/auth';
 import { SingleResponse } from 'utils/requestType';
 import { request } from 'utils/requests';
 
-import { SalesSummeryResponse } from './types';
+import { SalesSummaryResponse } from './types';
 
-type VendorQueryResult = SingleResponse<SalesSummeryResponse>;
+type MySalesSummaryQueryResult = SingleResponse<SalesSummaryResponse>;
 
 const getMySalesSummary = async (
   pathname: string,
-): Promise<VendorQueryResult> => {
+): Promise<MySalesSummaryQueryResult> => {
   const { data } = await request({
     pathname,
     method: 'get',
@@ -20,8 +20,8 @@ const getMySalesSummary = async (
 };
 
 export const useGetMySalesSummary = (): SWRResponse<
-  VendorQueryResult,
-  SingleResponse<SalesSummeryResponse>
+  MySalesSummaryQueryResult,
+  MySalesSummaryQueryResult
 > => {
   const response = useSWR('/me/sales-summary', getMySalesSummary);
 

--- a/src/utils/requestType.ts
+++ b/src/utils/requestType.ts
@@ -5,3 +5,4 @@ export type Meta = {
 };
 
 export type ListResponse<T> = { payload: T[]; meta: Meta };
+export type SingleResponse<T> = { payload: T; meta: Meta };


### PR DESCRIPTION
## PR 제안 사유
Resolve #103 

<!--
왜 이 PR을 제안하게 되었는지 간략하게 적어주세요.
이슈 내용만으로 설명이 된다면 생략 가능합니다.
-->

## 주요 변경 기록
- `/me/sales-summary` api 연동

<!--
간단하게라도 적어주세요.
변경된 자세한 내용을 적어주셔도 좋습니다.
-->

## Code review

### Code review 에서 중점적으로 봐야하는 부분
- 기존에 ListResponse 타입만 선언되어 있어서 리스트가 아닌 것들의 타입이 필요했는데 우선 SingleResponse .. 이고 더 적절한 네이밍 ?

<!-- 생략 가능합니다. -->

## Design review

### Design review 에서 중점적으로 봐야하는 부분 / 스크린샷

<!-- 생략 가능합니다. -->

## 기타 질문 및 특이 사항
기존 코드보고 최대한 스타일 맞춰서 작업했는데 아래 것들은 궁금한 사항 !
- SWRResponse Data, Error 타입이 동일한데 다르게 기입한 이유
```javascript
type VendorQueryResult = ListResponse<DesignItemResponse>;

export const useGetMyDesigns = (): SWRInfiniteResponse<
  VendorQueryResult,
  ListResponse<DesignItemResponse>
>
```
- SWR 도큐먼트 찾아보니까 첫번째 인자(getKey)를 두번째 인자(getMyDesigns)의 첫번째 인자로 받던데 아래처럼 풀어써야하는 이유가 있는지 .. ???

```javascript
const response = useSWR('/me/sales-summary', getMySalesSummary);

const response = useSWRInfinite(getKey, (pathname: string) =>
  getMyDesigns(pathname),
);
```

<!-- 생략 가능합니다. -->
