### PR TITLE
[Feat] 상품 구성하기 페이지 및 api 연동

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-ellipsis-component": "^1.0.1",
+    "react-images-uploading": "^3.1.3",
     "react-infinite-scroll-component": "^6.1.0",
     "react-query": "^3.23.2",
     "react-router-dom": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@date-io/date-fns": "^2.11.0",
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
+    "@material-ui/pickers": "^3.3.10",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@date-io/date-fns": "^2.11.0",
+    "@date-io/date-fns": "1.3.13",
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
@@ -14,6 +14,7 @@
     "@types/styled-components": "^5.1.7",
     "@types/url-parse": "^1.4.3",
     "axios": "^0.21.1",
+    "date-fns": "^2.24.0",
     "dayjs": "^1.10.6",
     "firebase": "^9.0.1",
     "jwt-decode": "^3.1.2",

--- a/src/components/CommonStepProgressBar/index.tsx
+++ b/src/components/CommonStepProgressBar/index.tsx
@@ -1,0 +1,73 @@
+import { Step, Stepper } from '@material-ui/core';
+import StepLabel from '@material-ui/core/StepLabel';
+import React from 'react';
+import styled, { css } from 'styled-components';
+import { palette } from 'themes/palette';
+import { zIndex } from 'themes/zIndex';
+
+import { PAGE_TYPE } from '../../pages/CreateProduct/types';
+
+interface StepIconProps {
+  active: boolean;
+  completed: boolean;
+}
+
+const StepIcon = styled.div<StepIconProps>`
+  color: ${palette.grey[200]};
+  display: flex;
+  height: 22px;
+  z-index: ${zIndex.mobileStepper};
+  align-items: center;
+  ${(props) =>
+    props.active &&
+    css`
+      color: ${palette.primary.main};
+    `};
+  div {
+    width: 15px;
+    height: 15px;
+    border-radius: 50%;
+    background-color: currentColor;
+
+    ${(props) =>
+      props.completed &&
+      css`
+        color: ${palette.primary.main};
+        font-size: 18px;
+      `};
+  }
+`;
+
+const StyledStepLabel = styled(StepLabel)`
+  word-break: keep-all;
+`;
+
+const renderStepIcon = (props: StepIconProps): React.ReactElement => {
+  return (
+    <StepIcon {...props}>
+      <div />
+    </StepIcon>
+  );
+};
+
+const CommonStepProgressBar = ({
+  steps,
+  currentStep,
+}: {
+  steps: string[];
+  currentStep: PAGE_TYPE;
+}): React.ReactElement => {
+  return (
+    <Stepper alternativeLabel activeStep={currentStep}>
+      {steps.map((label) => (
+        <Step key={label}>
+          <StyledStepLabel StepIconComponent={renderStepIcon}>
+            {label}
+          </StyledStepLabel>
+        </Step>
+      ))}
+    </Stepper>
+  );
+};
+
+export default CommonStepProgressBar;

--- a/src/components/CommonStepProgressBar/index.tsx
+++ b/src/components/CommonStepProgressBar/index.tsx
@@ -1,54 +1,13 @@
 import { Step, Stepper } from '@material-ui/core';
 import StepLabel from '@material-ui/core/StepLabel';
+import renderStepIcon from 'components/RenderStepIcon';
+import { PAGE_TYPE } from 'pages/CreateProduct/types';
 import React from 'react';
-import styled, { css } from 'styled-components';
-import { palette } from 'themes/palette';
-import { zIndex } from 'themes/zIndex';
-
-import { PAGE_TYPE } from '../../pages/CreateProduct/types';
-
-interface StepIconProps {
-  active: boolean;
-  completed: boolean;
-}
-
-const StepIcon = styled.div<StepIconProps>`
-  color: ${palette.grey[200]};
-  display: flex;
-  height: 22px;
-  z-index: ${zIndex.mobileStepper};
-  align-items: center;
-  ${(props) =>
-    props.active &&
-    css`
-      color: ${palette.primary.main};
-    `};
-  div {
-    width: 15px;
-    height: 15px;
-    border-radius: 50%;
-    background-color: currentColor;
-
-    ${(props) =>
-      props.completed &&
-      css`
-        color: ${palette.primary.main};
-        font-size: 18px;
-      `};
-  }
-`;
+import styled from 'styled-components';
 
 const StyledStepLabel = styled(StepLabel)`
   word-break: keep-all;
 `;
-
-const renderStepIcon = (props: StepIconProps): React.ReactElement => {
-  return (
-    <StepIcon {...props}>
-      <div />
-    </StepIcon>
-  );
-};
 
 const CommonStepProgressBar = ({
   steps,

--- a/src/components/RenderStepIcon/index.tsx
+++ b/src/components/RenderStepIcon/index.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+import { palette } from 'themes/palette';
+import { zIndex } from 'themes/zIndex';
+
+interface StepIconProps {
+  active: boolean;
+  completed: boolean;
+}
+
+const StepIcon = styled.div<StepIconProps>`
+  color: ${palette.grey[200]};
+  display: flex;
+  height: 22px;
+  z-index: ${zIndex.mobileStepper};
+  align-items: center;
+  ${(props) =>
+    props.active &&
+    css`
+      color: ${palette.primary.main};
+    `};
+  div {
+    width: 15px;
+    height: 15px;
+    border-radius: 50%;
+    background-color: currentColor;
+
+    ${(props) =>
+      props.completed &&
+      css`
+        color: ${palette.primary.main};
+        font-size: 18px;
+      `};
+  }
+`;
+
+const renderStepIcon = (props: StepIconProps): React.ReactElement => {
+  return (
+    <StepIcon {...props}>
+      <div />
+    </StepIcon>
+  );
+};
+
+export default renderStepIcon;

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -8,6 +8,7 @@ export const FAILED_TO_FETCH_ACCESS_TOKEN =
   '로그인에 실패하였습니다. 잠시 후 다시 시도해주세요.';
 export const FAILED_TO_GET_MY_DESIGNS =
   '내가 만든 도안 목록을 불러오는데 실패했습니다.';
+export const FAILED_TO_SAVE_PRODUCT = '상품 저장에 실패했습니다.';
 export const ONLY_UPLOAD_FILES_BELOW_10MB =
   '10MB 이하에 파일만 업로드할 수 있습니다';
 export const FAILED_TO_UPLOAD_IMAGE = '이미지 업로드에 실패했습니다';

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -3,6 +3,7 @@ export const ROOT_PATH = '/';
 export const MY_INFORMATION_ROUTER_ROOT = '/my';
 export const MY_INFORMATION_PROFILE_PATH = MY_INFORMATION_ROUTER_ROOT;
 export const MY_INFORMATION_CREATE_DESIGN_PATH = `${MY_INFORMATION_ROUTER_ROOT}/designs/create`;
+export const MY_INFORMATION_CREATE_PRODUCT_PATH = `${MY_INFORMATION_ROUTER_ROOT}/products/create`;
 
 export const LOGIN_ROUTER_ROOT = '/login';
 export const LOGIN_PATH = LOGIN_ROUTER_ROOT;

--- a/src/dumbs/InlineInput/index.tsx
+++ b/src/dumbs/InlineInput/index.tsx
@@ -1,8 +1,8 @@
-import { Grid, Input, Typography } from '@material-ui/core';
+import { Grid, Input as BaseInput, Typography } from '@material-ui/core';
 import { InputBaseComponentProps } from '@material-ui/core/InputBase';
 import { Variant } from '@material-ui/core/styles/createTypography';
 import React from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { theme } from 'themes';
 
 interface Props {
@@ -27,6 +27,16 @@ export const FormLabel = styled(Typography)`
 
 const InputGrid = styled(Grid)`
   width: auto;
+`;
+
+const Input = styled(BaseInput)<{ type?: string }>`
+  ${({ type }) =>
+    type === 'number' &&
+    css`
+      input {
+        text-align: right;
+      }
+    `}
 `;
 
 const InlineInput = ({

--- a/src/dumbs/InlineInput/index.tsx
+++ b/src/dumbs/InlineInput/index.tsx
@@ -1,0 +1,63 @@
+import { Grid, Input, Typography } from '@material-ui/core';
+import { InputBaseComponentProps } from '@material-ui/core/InputBase';
+import { Variant } from '@material-ui/core/styles/createTypography';
+import React from 'react';
+import styled from 'styled-components';
+import { theme } from 'themes';
+
+interface Props {
+  id: string;
+  type?: string;
+  label: string;
+  variant?: Variant | 'inherit';
+  value?: string | number;
+  placeholder?: string;
+  endAdornment?: React.ReactNode;
+  inputProps?: InputBaseComponentProps;
+  onChange: (
+    event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,
+  ) => void;
+}
+
+export const FormLabel = styled(Typography)`
+  width: 100%;
+  padding: ${theme.spacing(1)};
+  display: inline;
+`;
+
+const InputGrid = styled(Grid)`
+  width: auto;
+`;
+
+const InlineInput = ({
+  id,
+  type,
+  label,
+  variant,
+  value,
+  placeholder,
+  endAdornment,
+  onChange,
+}: Props): React.ReactElement => {
+  return (
+    <InputGrid container item alignItems={'center'}>
+      <Grid item>
+        <FormLabel variant={variant}>{label}</FormLabel>
+      </Grid>
+      <Grid item>
+        <Input
+          id={id}
+          type={type}
+          aria-describedby={id}
+          placeholder={placeholder}
+          endAdornment={endAdornment}
+          value={value}
+          onChange={onChange}
+          required
+        />
+      </Grid>
+    </InputGrid>
+  );
+};
+
+export default InlineInput;

--- a/src/dumbs/InlineInput/index.tsx
+++ b/src/dumbs/InlineInput/index.tsx
@@ -1,22 +1,17 @@
-import { Grid, Input as BaseInput, Typography } from '@material-ui/core';
-import { InputBaseComponentProps } from '@material-ui/core/InputBase';
+import {
+  Grid,
+  Input as BaseInput,
+  InputProps,
+  Typography,
+} from '@material-ui/core';
 import { Variant } from '@material-ui/core/styles/createTypography';
 import React from 'react';
 import styled, { css } from 'styled-components';
 import { theme } from 'themes';
 
-interface Props {
-  id: string;
-  type?: string;
+interface InlineInputProps extends InputProps {
   label: string;
   variant?: Variant | 'inherit';
-  value?: string | number;
-  placeholder?: string;
-  endAdornment?: React.ReactNode;
-  inputProps?: InputBaseComponentProps;
-  onChange: (
-    event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,
-  ) => void;
 }
 
 export const FormLabel = styled(Typography)`
@@ -39,32 +34,14 @@ const Input = styled(BaseInput)<{ type?: string }>`
     `}
 `;
 
-const InlineInput = ({
-  id,
-  type,
-  label,
-  variant,
-  value,
-  placeholder,
-  endAdornment,
-  onChange,
-}: Props): React.ReactElement => {
+const InlineInput = (props: InlineInputProps): React.ReactElement => {
   return (
     <InputGrid container item alignItems="center">
       <Grid item>
-        <FormLabel variant={variant}>{label}</FormLabel>
+        <FormLabel variant={props.variant}>{props.label}</FormLabel>
       </Grid>
       <Grid item>
-        <Input
-          id={id}
-          type={type}
-          aria-describedby={id}
-          placeholder={placeholder}
-          endAdornment={endAdornment}
-          value={value}
-          onChange={onChange}
-          required
-        />
+        <Input {...props} aria-describedby={props.id} required />
       </Grid>
     </InputGrid>
   );

--- a/src/dumbs/InlineInput/index.tsx
+++ b/src/dumbs/InlineInput/index.tsx
@@ -50,7 +50,7 @@ const InlineInput = ({
   onChange,
 }: Props): React.ReactElement => {
   return (
-    <InputGrid container item alignItems={'center'}>
+    <InputGrid container item alignItems="center">
       <Grid item>
         <FormLabel variant={variant}>{label}</FormLabel>
       </Grid>

--- a/src/pages/CreateDesign/components/Footer/index.tsx
+++ b/src/pages/CreateDesign/components/Footer/index.tsx
@@ -4,8 +4,7 @@ import { currentStepAtom } from 'pages/CreateDesign/recoils';
 import { PAGE } from 'pages/CreateDesign/types';
 import React from 'react';
 import { useRecoilValue } from 'recoil';
-
-import { FooterContainer } from './Footer.css';
+import { FooterContainer } from 'styles/constants';
 import { useStepController } from './hooks/useStepController';
 
 const Footer = (): React.ReactElement => {

--- a/src/pages/CreateDesign/components/Header/index.tsx
+++ b/src/pages/CreateDesign/components/Header/index.tsx
@@ -1,21 +1,11 @@
-import { Grid, Typography } from '@material-ui/core';
+import { Grid } from '@material-ui/core';
 import { currentStepAtom } from 'pages/CreateDesign/recoils';
 import { PAGE } from 'pages/CreateDesign/types';
 import React from 'react';
 import { useRecoilValue } from 'recoil';
-import styled from 'styled-components';
-import { theme } from 'themes';
+import { Title, Contents } from 'styles/constants';
 
 import StepProgressBar from '../StepProgressBar';
-
-const Title = styled(Typography)`
-  margin-bottom: ${theme.spacing(2)};
-  font-weight: 600;
-`;
-
-const Contents = styled(Typography)`
-  white-space: pre-line;
-`;
 
 const Header = (): React.ReactElement => {
   const currentStep = useRecoilValue(currentStepAtom);

--- a/src/pages/CreateDesign/components/StepProgressBar/index.tsx
+++ b/src/pages/CreateDesign/components/StepProgressBar/index.tsx
@@ -1,71 +1,13 @@
-import Step from '@material-ui/core/Step';
-import StepLabel from '@material-ui/core/StepLabel';
-import Stepper from '@material-ui/core/Stepper';
+import CommonStepProgressBar from 'components/CommonStepProgressBar';
 import { currentStepAtom } from 'pages/CreateDesign/recoils';
 import React from 'react';
 import { useRecoilValue } from 'recoil';
-import styled, { css } from 'styled-components';
-import { palette } from 'themes/palette';
-import { zIndex } from 'themes/zIndex';
-
-interface StepIconProps {
-  active: boolean;
-  completed: boolean;
-}
-
-const StepIcon = styled.div<StepIconProps>`
-  color: ${palette.grey[200]};
-  display: flex;
-  height: 22px;
-  z-index: ${zIndex.mobileStepper};
-  align-items: center;
-  ${(props) =>
-    props.active &&
-    css`
-      color: ${palette.primary.main};
-    `};
-  div {
-    width: 15px;
-    height: 15px;
-    border-radius: 50%;
-    background-color: currentColor;
-
-    ${(props) =>
-      props.completed &&
-      css`
-        color: ${palette.primary.main};
-        font-size: 18px;
-      `};
-  }
-`;
-
-const StyledStepLabel = styled(StepLabel)`
-  word-break: keep-all;
-`;
-
-const renderStepIcon = (props: StepIconProps): React.ReactElement => {
-  return (
-    <StepIcon {...props}>
-      <div />
-    </StepIcon>
-  );
-};
 
 const StepProgressBar = (): React.ReactElement => {
   const currentStep = useRecoilValue(currentStepAtom);
   const steps = ['기본 정보 입력', '도안 작성', '최종 확인'];
 
-  return (
-    <Stepper alternativeLabel activeStep={currentStep}>
-      {steps.map((label) => (
-        <Step key={label}>
-          <StyledStepLabel StepIconComponent={renderStepIcon}>
-            {label}
-          </StyledStepLabel>
-        </Step>
-      ))}
-    </Stepper>
-  );
+  return <CommonStepProgressBar steps={steps} currentStep={currentStep} />;
 };
 
 export default StepProgressBar;

--- a/src/pages/CreateProduct/Package/index.tsx
+++ b/src/pages/CreateProduct/Package/index.tsx
@@ -110,31 +110,36 @@ const Package = (): React.ReactElement => {
   };
 
   const renderSalesDateInfoMessage = (): ReactNode => {
+    const invalidDateRange =
+      dayjs(specifiedSalesStartDate).valueOf() >
+      dayjs(specifiedSalesEndDate).valueOf();
+
     let fontColor = '#808080';
     let message = '상품이 등록된 이후부터 계속해서 판매됩니다.';
 
-    if (specifiedSalesStartDate && specifiedSalesEndDate) {
-      if (
-        dayjs(specifiedSalesStartDate).valueOf() >
-        dayjs(specifiedSalesEndDate).valueOf()
-      ) {
-        fontColor = '#ff0000';
-        message = '종료일은 시작일보다 커야 합니다.';
-      } else {
-        message = `
+    if (specifiedSalesStartDate || specifiedSalesEndDate) {
+      if (specifiedSalesStartDate) {
+        message = `${formatDate(
+          specifiedSalesStartDate,
+        )} 이후부터 계속해서 판매됩니다.`;
+      }
+      if (specifiedSalesEndDate) {
+        message = `상품이 등록된 이후부터 ${formatDate(
+          specifiedSalesEndDate,
+        )} 까지
+          판매됩니다.`;
+      }
+      if (specifiedSalesStartDate && specifiedSalesEndDate) {
+        if (invalidDateRange) {
+          fontColor = '#ff0000';
+          message = '종료일은 시작일보다 커야 합니다.';
+        } else {
+          message = `
           ${formatDate(specifiedSalesStartDate)} 이후부터
           ${formatDate(specifiedSalesEndDate)}까지 판매됩니다.
         `;
+        }
       }
-    } else if (specifiedSalesStartDate) {
-      message = `${formatDate(
-        specifiedSalesStartDate,
-      )} 이후부터 계속해서 판매됩니다.`;
-    } else if (specifiedSalesEndDate) {
-      message = `상품이 등록된 이후부터 ${formatDate(
-        specifiedSalesEndDate,
-      )} 까지
-          판매됩니다.`;
     }
 
     return (

--- a/src/pages/CreateProduct/Package/index.tsx
+++ b/src/pages/CreateProduct/Package/index.tsx
@@ -294,7 +294,6 @@ const Package = (): React.ReactElement => {
                 KeyboardButtonProps={{
                   'aria-label': 'change date',
                 }}
-                invalidDateMessage=""
               />
               <Wave>~</Wave>
               <KeyboardDatePicker
@@ -307,7 +306,6 @@ const Package = (): React.ReactElement => {
                 KeyboardButtonProps={{
                   'aria-label': 'change date',
                 }}
-                invalidDateMessage=""
               />
             </Grid>
           </MuiPickersUtilsProvider>

--- a/src/pages/CreateProduct/Package/index.tsx
+++ b/src/pages/CreateProduct/Package/index.tsx
@@ -39,9 +39,11 @@ const Rate = styled.span`
   font-size: ${theme.spacing(1.75)};
 `;
 
-const SalesDateInfo = styled(Typography)<{ fontcolor?: string }>`
+const SalesDateInfo = styled(Typography)<{
+  isInvalid?: boolean;
+}>`
   margin-top: ${theme.spacing(1)};
-  color: ${({ fontcolor }) => fontcolor};
+  color: ${({ isInvalid }) => (isInvalid ? '#ff0000' : '#808080')};
 `;
 
 const Wave = styled.span`
@@ -114,7 +116,7 @@ const Package = (): React.ReactElement => {
       dayjs(specifiedSalesStartDate).valueOf() >
       dayjs(specifiedSalesEndDate).valueOf();
 
-    let fontColor = '#808080';
+    let isInvalid = false;
     let message = '상품이 등록된 이후부터 계속해서 판매됩니다.';
 
     if (specifiedSalesStartDate || specifiedSalesEndDate) {
@@ -131,7 +133,7 @@ const Package = (): React.ReactElement => {
       }
       if (specifiedSalesStartDate && specifiedSalesEndDate) {
         if (invalidDateRange) {
-          fontColor = '#ff0000';
+          isInvalid = true;
           message = '종료일은 시작일보다 커야 합니다.';
         } else {
           message = `
@@ -143,7 +145,7 @@ const Package = (): React.ReactElement => {
     }
 
     return (
-      <SalesDateInfo variant="h5" fontcolor={fontColor}>
+      <SalesDateInfo variant="h5" isInvalid={isInvalid}>
         {message}
       </SalesDateInfo>
     );

--- a/src/pages/CreateProduct/Package/index.tsx
+++ b/src/pages/CreateProduct/Package/index.tsx
@@ -1,0 +1,299 @@
+import DateFnsUtils from '@date-io/date-fns';
+import {
+  Grid,
+  Input,
+  InputAdornment,
+  InputLabel,
+  InputProps,
+  Typography,
+} from '@material-ui/core';
+import {
+  MuiPickersUtilsProvider,
+  KeyboardDatePicker,
+  DatePickerProps,
+} from '@material-ui/pickers';
+import dayjs from 'dayjs';
+import { FormLabel, RequiredInput, RequiredMark } from 'dumbs';
+import InlineInput from 'dumbs/InlineInput';
+import React, { ReactNode } from 'react';
+import { useRecoilState } from 'recoil';
+import styled from 'styled-components';
+import { theme } from 'themes';
+import { formatDate } from 'utils/format';
+
+import { currentProductInputAtom } from '../recoils';
+
+const FullWidthInput = styled(Input)`
+  width: 100%;
+`;
+
+const Rate = styled.span`
+  color: ${theme.palette.primary.main};
+  margin-left: ${theme.spacing(2)};
+  font-size: ${theme.spacing(1.75)};
+`;
+
+const SalesDateInfo = styled(Typography)<{ isInvalid?: boolean }>`
+  color: ${(props) => (props.isInvalid ? '#ff0000' : '#808080')};
+`;
+
+const Package = (): React.ReactElement => {
+  const [currentProductInput, setCurrentProductInput] = useRecoilState(
+    currentProductInputAtom,
+  );
+  const {
+    name,
+    fullPrice,
+    discountPrice,
+    representativeImageUrl,
+    specifiedSalesStartDate,
+    specifiedSalesEndDate,
+    tags,
+    designIds,
+  } = currentProductInput;
+
+  const getRate = (): string => {
+    const rate = Math.round(
+      (currentProductInput.discountPrice / currentProductInput.fullPrice) * 100,
+    );
+
+    return isNaN(rate) ? '' : rate.toString();
+  };
+
+  const getSalePrice = (): number => {
+    return currentProductInput.fullPrice - currentProductInput.discountPrice;
+  };
+
+  const renderSalesDateInfoMessage = (): ReactNode => {
+    let isInvalid = false;
+    let message = '상품이 등록된 이후부터 계속해서 판매됩니다.';
+
+    if (specifiedSalesStartDate && specifiedSalesEndDate) {
+      if (
+        dayjs(specifiedSalesStartDate).valueOf() >
+        dayjs(specifiedSalesEndDate).valueOf()
+      ) {
+        isInvalid = true;
+        message = '종료일은 시작일보다 커야 합니다.';
+      } else {
+        message = `
+          ${formatDate(specifiedSalesStartDate)} 이후부터
+          ${formatDate(specifiedSalesEndDate)}까지 판매됩니다.
+        `;
+      }
+    } else if (specifiedSalesStartDate) {
+      message = `${formatDate(
+        specifiedSalesStartDate,
+      )} 이후부터 계속해서 판매됩니다.`;
+    } else if (specifiedSalesEndDate) {
+      message = `상품이 등록된 이후부터 ${formatDate(
+        specifiedSalesEndDate,
+      )} 까지
+          판매됩니다.`;
+    }
+
+    return (
+      <SalesDateInfo variant="h5" isInvalid={isInvalid}>
+        {message}
+      </SalesDateInfo>
+    );
+  };
+
+  const onChangeName: InputProps['onChange'] = ({ currentTarget }) => {
+    setCurrentProductInput({
+      ...currentProductInput,
+      name: currentTarget.value,
+    });
+  };
+
+  const onChangeFullPrice: InputProps['onChange'] = ({ currentTarget }) => {
+    setCurrentProductInput({
+      ...currentProductInput,
+      fullPrice: Number(currentTarget.value),
+    });
+  };
+
+  const onChangeDiscountPrice: InputProps['onChange'] = ({ currentTarget }) => {
+    setCurrentProductInput({
+      ...currentProductInput,
+      discountPrice: Number(currentTarget.value),
+    });
+  };
+
+  const onChangeTags: InputProps['onChange'] = ({ currentTarget }) => {
+    setCurrentProductInput({
+      ...currentProductInput,
+      tags: currentTarget.value.split('#').map((tag) => tag.trim()),
+    });
+  };
+
+  const onChangeSpecifiedSalesStartDate: DatePickerProps['onChange'] = (
+    date,
+  ) => {
+    setCurrentProductInput({
+      ...currentProductInput,
+      specifiedSalesStartDate: date?.toString() || '',
+    });
+  };
+
+  const onChangeSpecifiedSalesEndDate: DatePickerProps['onChange'] = (date) => {
+    setCurrentProductInput({
+      ...currentProductInput,
+      specifiedSalesEndDate: date?.toString() || '',
+    });
+  };
+
+  return (
+    <form>
+      <Grid container>
+        <Grid item xs={12}>
+          <RequiredInput
+            id="name"
+            variant="h5"
+            label="상품명"
+            placeholder="예) 이름이 아주 길고 기다란 엄청 길고 긴 무척이나 길고 길었던 도안 외 1종"
+            value={name}
+            onChange={onChangeName}
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <FormLabel variant="h5">
+            판매가
+            <RequiredMark />
+          </FormLabel>
+          <InlineInput
+            id="fullPrice"
+            type="number"
+            label="정가"
+            variant="h6"
+            value={fullPrice}
+            aria-describedby="fullPrice"
+            endAdornment={<InputAdornment position="end">원</InputAdornment>}
+            onChange={onChangeFullPrice}
+          />
+          <Grid container>
+            <InlineInput
+              id="discountPrice"
+              type="number"
+              label="할인"
+              variant="h6"
+              value={discountPrice}
+              aria-describedby="discountPrice"
+              endAdornment={<InputAdornment position="end">원</InputAdornment>}
+              onChange={onChangeDiscountPrice}
+            />
+            {getRate() && (
+              <Rate>
+                <b>{getRate()}%</b> 할인
+              </Rate>
+            )}
+          </Grid>
+          <InputLabel>판매가</InputLabel>
+          {getSalePrice()}원
+        </Grid>
+        <Grid item xs={12}>
+          <FormLabel variant="h5">
+            대표 이미지
+            <RequiredMark />
+          </FormLabel>
+          <img src="//via.placeholder.com/100x100" loading="lazy" />
+        </Grid>
+        <Grid item xs={12}>
+          <FormLabel variant="h5">판매 기간</FormLabel>
+          <MuiPickersUtilsProvider utils={DateFnsUtils}>
+            <Grid container>
+              <KeyboardDatePicker
+                disableToolbar
+                variant="inline"
+                format="yyyy/MM/dd"
+                margin="normal"
+                id="date-picker-inline"
+                value={specifiedSalesStartDate}
+                onChange={onChangeSpecifiedSalesStartDate}
+                KeyboardButtonProps={{
+                  'aria-label': 'change date',
+                }}
+                invalidDateMessage=""
+              />
+              ~
+              <KeyboardDatePicker
+                disableToolbar
+                variant="inline"
+                format="yyyy/MM/dd"
+                margin="normal"
+                id="date-picker-inline"
+                value={specifiedSalesEndDate}
+                onChange={onChangeSpecifiedSalesEndDate}
+                KeyboardButtonProps={{
+                  'aria-label': 'change date',
+                }}
+                invalidDateMessage=""
+              />
+            </Grid>
+          </MuiPickersUtilsProvider>
+        </Grid>
+        <Grid item xs={12}>
+          {renderSalesDateInfoMessage()}
+        </Grid>
+        <Grid item xs={12}>
+          <FormLabel variant="h5">검색 태그</FormLabel>
+          <FullWidthInput
+            id="tags"
+            placeholder="예) #앙고라니트 #터틀넥니트"
+            value={tags}
+            onChange={onChangeTags}
+          />
+        </Grid>
+        {/* <Grid item xs={12}>*/}
+        {/*  <RequiredInput*/}
+        {/*    id="name"*/}
+        {/*    variant="h5"*/}
+        {/*    label="상품명"*/}
+        {/*    placeholder="예) 이름이 아주 길고 기다란 엄청 길고 긴 무척이나 길고 길었던 도안 외 1종"*/}
+        {/*    value={name}*/}
+        {/*    onChange={onChangeName}*/}
+        {/*  />*/}
+        {/* </Grid>*/}
+        {/* <Grid item xs={12}>*/}
+        {/*  <h4>판매가</h4>*/}
+        {/*  <RequiredMark />*/}
+        {/* </Grid>*/}
+        {/* <Grid item xs={12}>*/}
+        {/*  <FormLabel>정가</FormLabel>*/}
+        {/*  <Input*/}
+        {/*    id="fullPrice"*/}
+        {/*    type="number"*/}
+        {/*    aria-describedby="fullPrice"*/}
+        {/*    endAdornment={<InputAdornment position="end">원</InputAdornment>}*/}
+        {/*    value={fullPrice}*/}
+        {/*    onChange={onChangeFullPrice}*/}
+        {/*  />*/}
+        {/* </Grid>*/}
+        {/* <Grid item xs={12}>*/}
+        {/*  <FormLabel>할인</FormLabel>*/}
+        {/*  <Input*/}
+        {/*    id="discountPrice"*/}
+        {/*    type="number"*/}
+        {/*    aria-describedby="discountPrice"*/}
+        {/*    endAdornment={<InputAdornment position="end">원</InputAdornment>}*/}
+        {/*    value={discountPrice}*/}
+        {/*    onChange={onChangeFullPrice}*/}
+        {/*  />*/}
+        {/*  <span>{getRate}%</span>*/}
+        {/* </Grid>*/}
+      </Grid>
+    </form>
+  );
+};
+
+export default Package;
+
+// "id": null,
+//   "name": "대충 살자",
+//   "full_price": 10000,
+//   "discount_price": 1000,
+//   "representative_image_url": "https://t1.daumcdn.net/cfile/tistory/9904134E5CA5480229",
+//   "specified_sales_start_date": null,
+//   "specified_sales_end_date": null,
+//   "tags": ["서술형 도안"],
+//   "design_ids": [1, 2, 3]

--- a/src/pages/CreateProduct/Package/index.tsx
+++ b/src/pages/CreateProduct/Package/index.tsx
@@ -107,6 +107,8 @@ const Package = (): React.ReactElement => {
     return isNaN(rate) ? '' : rate.toString();
   };
 
+  const rate = getRate();
+
   const getSalePrice = (): number => {
     return currentProductInput.fullPrice - currentProductInput.discountPrice;
   };
@@ -238,9 +240,9 @@ const Package = (): React.ReactElement => {
               endAdornment={<InputAdornment position="end">원</InputAdornment>}
               onChange={onChangeDiscountPrice}
             />
-            {getRate() && (
+            {rate && (
               <Rate>
-                <b>{getRate()}%</b> 할인
+                <b>{rate}%</b> 할인
               </Rate>
             )}
           </Row>

--- a/src/pages/CreateProduct/Package/index.tsx
+++ b/src/pages/CreateProduct/Package/index.tsx
@@ -23,6 +23,10 @@ import { formatDate } from 'utils/format';
 
 import { currentProductInputAtom } from '../recoils';
 
+const Row = styled(Grid)`
+  margin-top: ${theme.spacing(2)};
+`;
+
 const FullWidthInput = styled(Input)`
   width: 100%;
 `;
@@ -34,7 +38,12 @@ const Rate = styled.span`
 `;
 
 const SalesDateInfo = styled(Typography)<{ isInvalid?: boolean }>`
+  margin-top: ${theme.spacing(1)};
   color: ${(props) => (props.isInvalid ? '#ff0000' : '#808080')};
+`;
+
+const Wave = styled.span`
+  margin: 0 ${theme.spacing(1)};
 `;
 
 const Package = (): React.ReactElement => {
@@ -146,7 +155,7 @@ const Package = (): React.ReactElement => {
   return (
     <form>
       <Grid container>
-        <Grid item xs={12}>
+        <Row item xs={12}>
           <RequiredInput
             id="name"
             variant="h5"
@@ -155,8 +164,8 @@ const Package = (): React.ReactElement => {
             value={name}
             onChange={onChangeName}
           />
-        </Grid>
-        <Grid item xs={12}>
+        </Row>
+        <Row item xs={12}>
           <FormLabel variant="h5">
             판매가
             <RequiredMark />
@@ -171,7 +180,7 @@ const Package = (): React.ReactElement => {
             endAdornment={<InputAdornment position="end">원</InputAdornment>}
             onChange={onChangeFullPrice}
           />
-          <Grid container>
+          <Row container>
             <InlineInput
               id="discountPrice"
               type="number"
@@ -187,26 +196,29 @@ const Package = (): React.ReactElement => {
                 <b>{getRate()}%</b> 할인
               </Rate>
             )}
-          </Grid>
-          <InputLabel>판매가</InputLabel>
-          {getSalePrice()}원
-        </Grid>
-        <Grid item xs={12}>
+          </Row>
+          <Row alignItems="center" container item>
+            <Grid item>
+              <FormLabel variant="h6">판매가</FormLabel>
+            </Grid>
+            <Grid item>{getSalePrice()}원</Grid>
+          </Row>
+        </Row>
+        <Row item xs={12}>
           <FormLabel variant="h5">
             대표 이미지
             <RequiredMark />
           </FormLabel>
           <img src="//via.placeholder.com/100x100" loading="lazy" />
-        </Grid>
-        <Grid item xs={12}>
+        </Row>
+        <Row item xs={12}>
           <FormLabel variant="h5">판매 기간</FormLabel>
           <MuiPickersUtilsProvider utils={DateFnsUtils}>
-            <Grid container>
+            <Grid alignItems="center" container>
               <KeyboardDatePicker
                 disableToolbar
                 variant="inline"
                 format="yyyy/MM/dd"
-                margin="normal"
                 id="date-picker-inline"
                 value={specifiedSalesStartDate}
                 onChange={onChangeSpecifiedSalesStartDate}
@@ -215,12 +227,11 @@ const Package = (): React.ReactElement => {
                 }}
                 invalidDateMessage=""
               />
-              ~
+              <Wave>~</Wave>
               <KeyboardDatePicker
                 disableToolbar
                 variant="inline"
                 format="yyyy/MM/dd"
-                margin="normal"
                 id="date-picker-inline"
                 value={specifiedSalesEndDate}
                 onChange={onChangeSpecifiedSalesEndDate}
@@ -231,11 +242,11 @@ const Package = (): React.ReactElement => {
               />
             </Grid>
           </MuiPickersUtilsProvider>
-        </Grid>
+        </Row>
         <Grid item xs={12}>
           {renderSalesDateInfoMessage()}
         </Grid>
-        <Grid item xs={12}>
+        <Row item xs={12}>
           <FormLabel variant="h5">검색 태그</FormLabel>
           <FullWidthInput
             id="tags"
@@ -243,44 +254,7 @@ const Package = (): React.ReactElement => {
             value={tags}
             onChange={onChangeTags}
           />
-        </Grid>
-        {/* <Grid item xs={12}>*/}
-        {/*  <RequiredInput*/}
-        {/*    id="name"*/}
-        {/*    variant="h5"*/}
-        {/*    label="상품명"*/}
-        {/*    placeholder="예) 이름이 아주 길고 기다란 엄청 길고 긴 무척이나 길고 길었던 도안 외 1종"*/}
-        {/*    value={name}*/}
-        {/*    onChange={onChangeName}*/}
-        {/*  />*/}
-        {/* </Grid>*/}
-        {/* <Grid item xs={12}>*/}
-        {/*  <h4>판매가</h4>*/}
-        {/*  <RequiredMark />*/}
-        {/* </Grid>*/}
-        {/* <Grid item xs={12}>*/}
-        {/*  <FormLabel>정가</FormLabel>*/}
-        {/*  <Input*/}
-        {/*    id="fullPrice"*/}
-        {/*    type="number"*/}
-        {/*    aria-describedby="fullPrice"*/}
-        {/*    endAdornment={<InputAdornment position="end">원</InputAdornment>}*/}
-        {/*    value={fullPrice}*/}
-        {/*    onChange={onChangeFullPrice}*/}
-        {/*  />*/}
-        {/* </Grid>*/}
-        {/* <Grid item xs={12}>*/}
-        {/*  <FormLabel>할인</FormLabel>*/}
-        {/*  <Input*/}
-        {/*    id="discountPrice"*/}
-        {/*    type="number"*/}
-        {/*    aria-describedby="discountPrice"*/}
-        {/*    endAdornment={<InputAdornment position="end">원</InputAdornment>}*/}
-        {/*    value={discountPrice}*/}
-        {/*    onChange={onChangeFullPrice}*/}
-        {/*  />*/}
-        {/*  <span>{getRate}%</span>*/}
-        {/* </Grid>*/}
+        </Row>
       </Grid>
     </form>
   );

--- a/src/pages/CreateProduct/Package/index.tsx
+++ b/src/pages/CreateProduct/Package/index.tsx
@@ -6,6 +6,7 @@ import {
   InputProps,
   Typography,
 } from '@material-ui/core';
+import { Close } from '@material-ui/icons';
 import {
   MuiPickersUtilsProvider,
   KeyboardDatePicker,
@@ -15,6 +16,8 @@ import dayjs from 'dayjs';
 import { FormLabel, RequiredInput, RequiredMark } from 'dumbs';
 import InlineInput from 'dumbs/InlineInput';
 import React, { ReactNode } from 'react';
+import ImageUploading from 'react-images-uploading';
+import { ImageListType } from 'react-images-uploading/dist/typings';
 import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
 import { theme } from 'themes';
@@ -45,6 +48,41 @@ const Wave = styled.span`
   margin: 0 ${theme.spacing(1)};
 `;
 
+const ImageWrapper = styled(Grid)`
+  margin: ${theme.spacing(-1)};
+`;
+
+const ImageItem = styled(Grid)`
+  margin: ${theme.spacing(1)};
+  position: relative;
+`;
+
+const CloseButton = styled(Close)`
+  position: absolute;
+  top: ${theme.spacing(1)};
+  right: ${theme.spacing(1)};
+`;
+
+const ImageUploader = styled.button`
+  margin: ${theme.spacing(1)};
+  border-radius: ${theme.spacing(5)};
+  background: none;
+  color: inherit;
+  border: ${theme.spacing(0.25)} solid ${theme.palette.grey[200]};
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  outline: inherit;
+  width: ${theme.spacing(20)};
+  height: ${theme.spacing(20)};
+`;
+
+const ImagePreview = styled.img`
+  border-radius: ${theme.spacing(5)};
+  width: ${theme.spacing(20)};
+  height: ${theme.spacing(20)};
+`;
+
 const Package = (): React.ReactElement => {
   const [currentProductInput, setCurrentProductInput] = useRecoilState(
     currentProductInputAtom,
@@ -53,11 +91,11 @@ const Package = (): React.ReactElement => {
     name,
     fullPrice,
     discountPrice,
-    representativeImageUrl,
     specifiedSalesStartDate,
     specifiedSalesEndDate,
     tags,
   } = currentProductInput;
+  const [images, setImages] = React.useState<ImageListType>([]);
 
   const getRate = (): string => {
     const rate = Math.round(
@@ -150,6 +188,10 @@ const Package = (): React.ReactElement => {
     });
   };
 
+  const onChangeImages = (imageList: ImageListType) => {
+    setImages(imageList);
+  };
+
   return (
     <form>
       <Grid container>
@@ -207,7 +249,27 @@ const Package = (): React.ReactElement => {
             대표 이미지
             <RequiredMark />
           </FormLabel>
-          <img src={representativeImageUrl} loading="lazy" alt="대표 이미지" />
+          <ImageUploading
+            multiple
+            value={images}
+            onChange={onChangeImages}
+            maxNumber={3}
+            dataURLKey="data_url"
+          >
+            {({ imageList, onImageUpload, onImageRemove }) => (
+              <ImageWrapper container>
+                {imageList.map((image, index) => (
+                  <ImageItem key={index} item>
+                    <ImagePreview src={image.data_url} alt="" />
+                    <CloseButton onClick={() => onImageRemove(index)} />
+                  </ImageItem>
+                ))}
+                <ImageUploader onClick={onImageUpload}>
+                  새로 업로드하기
+                </ImageUploader>
+              </ImageWrapper>
+            )}
+          </ImageUploading>
         </Row>
         <Row item xs={12}>
           <FormLabel variant="h5">판매 기간</FormLabel>
@@ -259,13 +321,3 @@ const Package = (): React.ReactElement => {
 };
 
 export default Package;
-
-// "id": null,
-//   "name": "대충 살자",
-//   "full_price": 10000,
-//   "discount_price": 1000,
-//   "representative_image_url": "https://t1.daumcdn.net/cfile/tistory/9904134E5CA5480229",
-//   "specified_sales_start_date": null,
-//   "specified_sales_end_date": null,
-//   "tags": ["서술형 도안"],
-//   "design_ids": [1, 2, 3]

--- a/src/pages/CreateProduct/Package/index.tsx
+++ b/src/pages/CreateProduct/Package/index.tsx
@@ -3,7 +3,6 @@ import {
   Grid,
   Input,
   InputAdornment,
-  InputLabel,
   InputProps,
   Typography,
 } from '@material-ui/core';
@@ -37,9 +36,9 @@ const Rate = styled.span`
   font-size: ${theme.spacing(1.75)};
 `;
 
-const SalesDateInfo = styled(Typography)<{ isInvalid?: boolean }>`
+const SalesDateInfo = styled(Typography)<{ fontcolor?: string }>`
   margin-top: ${theme.spacing(1)};
-  color: ${(props) => (props.isInvalid ? '#ff0000' : '#808080')};
+  color: ${({ fontcolor }) => fontcolor};
 `;
 
 const Wave = styled.span`
@@ -58,7 +57,6 @@ const Package = (): React.ReactElement => {
     specifiedSalesStartDate,
     specifiedSalesEndDate,
     tags,
-    designIds,
   } = currentProductInput;
 
   const getRate = (): string => {
@@ -74,7 +72,7 @@ const Package = (): React.ReactElement => {
   };
 
   const renderSalesDateInfoMessage = (): ReactNode => {
-    let isInvalid = false;
+    let fontColor = '#808080';
     let message = '상품이 등록된 이후부터 계속해서 판매됩니다.';
 
     if (specifiedSalesStartDate && specifiedSalesEndDate) {
@@ -82,7 +80,7 @@ const Package = (): React.ReactElement => {
         dayjs(specifiedSalesStartDate).valueOf() >
         dayjs(specifiedSalesEndDate).valueOf()
       ) {
-        isInvalid = true;
+        fontColor = '#ff0000';
         message = '종료일은 시작일보다 커야 합니다.';
       } else {
         message = `
@@ -102,7 +100,7 @@ const Package = (): React.ReactElement => {
     }
 
     return (
-      <SalesDateInfo variant="h5" isInvalid={isInvalid}>
+      <SalesDateInfo variant="h5" fontcolor={fontColor}>
         {message}
       </SalesDateInfo>
     );
@@ -132,7 +130,7 @@ const Package = (): React.ReactElement => {
   const onChangeTags: InputProps['onChange'] = ({ currentTarget }) => {
     setCurrentProductInput({
       ...currentProductInput,
-      tags: currentTarget.value.split('#').map((tag) => tag.trim()),
+      tags: currentTarget.value,
     });
   };
 
@@ -141,14 +139,14 @@ const Package = (): React.ReactElement => {
   ) => {
     setCurrentProductInput({
       ...currentProductInput,
-      specifiedSalesStartDate: date?.toString() || '',
+      specifiedSalesStartDate: date?.toISOString(),
     });
   };
 
   const onChangeSpecifiedSalesEndDate: DatePickerProps['onChange'] = (date) => {
     setCurrentProductInput({
       ...currentProductInput,
-      specifiedSalesEndDate: date?.toString() || '',
+      specifiedSalesEndDate: date?.toISOString(),
     });
   };
 
@@ -209,7 +207,7 @@ const Package = (): React.ReactElement => {
             대표 이미지
             <RequiredMark />
           </FormLabel>
-          <img src="//via.placeholder.com/100x100" loading="lazy" />
+          <img src={representativeImageUrl} loading="lazy" alt="대표 이미지" />
         </Row>
         <Row item xs={12}>
           <FormLabel variant="h5">판매 기간</FormLabel>

--- a/src/pages/CreateProduct/components/Footer/index.tsx
+++ b/src/pages/CreateProduct/components/Footer/index.tsx
@@ -1,0 +1,91 @@
+import { Button as MaterialButton } from '@material-ui/core';
+import { Button } from 'dumbs';
+import {
+  currentProductInputAtom,
+  currentStepAtom,
+} from 'pages/CreateProduct/recoils';
+import { PAGE } from 'pages/CreateProduct/types';
+import React from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { FooterContainer } from 'styles/constants';
+
+const Footer = (): React.ReactElement => {
+  const [currentStep, setCurrentStep] = useRecoilState(currentStepAtom);
+  const {
+    name,
+    fullPrice,
+    discountPrice,
+    representativeImageUrl,
+    specifiedSalesStartDate,
+    specifiedSalesEndDate,
+    tags,
+    designIds,
+  } = useRecoilValue(currentProductInputAtom);
+
+  const saveProduct = () => {
+    console.log('저장');
+  };
+
+  const handleOnClickPrevious = (): void => {
+    switch (currentStep) {
+      case PAGE.PACKAGE:
+        setCurrentStep(PAGE.DESIGN);
+        break;
+      case PAGE.INTRODUCTION:
+        setCurrentStep(PAGE.PACKAGE);
+        break;
+      case PAGE.CONFIRM:
+        setCurrentStep(PAGE.INTRODUCTION);
+        break;
+      default:
+        break;
+    }
+  };
+
+  const renderNextLabel = (): string => {
+    switch (currentStep) {
+      case PAGE.DESIGN:
+        return '도안 선택 완료';
+      case PAGE.PACKAGE:
+        return '상품 구성 완료';
+      case PAGE.INTRODUCTION:
+        return '상품 소개 완료';
+      case PAGE.CONFIRM:
+        return '판매 시작';
+      default:
+        return '도안 선택 완료';
+    }
+  };
+
+  const handleOnClickNext = (): void => {
+    switch (currentStep) {
+      case PAGE.DESIGN:
+        setCurrentStep(PAGE.PACKAGE);
+        break;
+      case PAGE.PACKAGE:
+        setCurrentStep(PAGE.INTRODUCTION);
+        break;
+      case PAGE.INTRODUCTION:
+        setCurrentStep(PAGE.CONFIRM);
+        break;
+      case PAGE.CONFIRM:
+        saveProduct();
+        break;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <FooterContainer>
+      {currentStep !== PAGE.DESIGN && (
+        <MaterialButton variant="contained" onClick={handleOnClickPrevious}>
+          이전
+        </MaterialButton>
+      )}
+      <Button label={renderNextLabel()} onClick={handleOnClickNext} />
+    </FooterContainer>
+  );
+};
+
+export default Footer;

--- a/src/pages/CreateProduct/components/Footer/index.tsx
+++ b/src/pages/CreateProduct/components/Footer/index.tsx
@@ -99,13 +99,12 @@ const Footer = (): React.ReactElement => {
         setCurrentStep(PAGE.PACKAGE);
         break;
       case PAGE.PACKAGE:
-        setCurrentStep(PAGE.INTRODUCTION);
+        saveProduct();
         break;
       case PAGE.INTRODUCTION:
         setCurrentStep(PAGE.CONFIRM);
         break;
       case PAGE.CONFIRM:
-        saveProduct();
         break;
       default:
         break;

--- a/src/pages/CreateProduct/components/Header/index.tsx
+++ b/src/pages/CreateProduct/components/Header/index.tsx
@@ -1,0 +1,71 @@
+import { Grid } from '@material-ui/core';
+import { currentStepAtom } from 'pages/CreateProduct/recoils';
+import { PAGE } from 'pages/CreateProduct/types';
+import React from 'react';
+import { useRecoilValue } from 'recoil';
+import { Title, Contents } from 'styles/constants';
+
+import StepProgressBar from '../StepProgressBar';
+
+const Header = (): React.ReactElement => {
+  const currentStep = useRecoilValue(currentStepAtom);
+
+  const getStepContents = (): { title: string; detailContents: string } => {
+    const defaultContents = {
+      title: '💁 판매할 도안 선택하기',
+      detailContents:
+        '판매하고 싶은 도안을 아래에서 선택해주세요!\n여러 도안을 함께 묶어 세트로 판매해도 좋아요 😊\n많은 니터분들이 관심을 가질 수 있도록 구성해봐요!',
+    };
+
+    switch (currentStep) {
+      case PAGE.DESIGN:
+        return defaultContents;
+      case PAGE.PACKAGE:
+        return {
+          title: '📦 상품 구성하기',
+          detailContents:
+            '도안을 어떻게 판매할 것인지 상품을 구성해보세요!\n적절한 상품 구성은 더 많은 판매로 이어질 수 있어요! 🤭',
+        };
+      case PAGE.INTRODUCTION:
+        return {
+          title: '💬 상품에 대해 소개하기',
+          detailContents:
+            '이 상품에 대해 니터들에게 소개해주세요!\n도안을 따라 뜨개질을 하다보면 어떤 편물이 나오는지\n결과물을 공유해준다면,  더 많은 니터들이 믿고 구매할 수 있을거예요! 😉',
+        };
+      case PAGE.CONFIRM:
+        return {
+          title: '🔍 확인하기',
+          detailContents:
+            '다른 니터들에게 상품이 어떻게 노출될지 확인해보세요!\n수정되면 좋을 부분은 없는지 꼼꼼히 확인해봐요! 👀',
+        };
+      default:
+        return defaultContents;
+    }
+  };
+
+  const renderTitles = (): string => {
+    const { title } = getStepContents();
+
+    return title;
+  };
+
+  const renderContents = (): string => {
+    const { detailContents } = getStepContents();
+
+    return detailContents;
+  };
+
+  return (
+    <Grid container>
+      <Grid item xs={12} sm={8}>
+        <Title variant="h3">{renderTitles()}</Title>
+        <Contents>{renderContents()}</Contents>
+      </Grid>
+      <Grid item xs={12} sm={4}>
+        <StepProgressBar />
+      </Grid>
+    </Grid>
+  );
+};
+
+export default Header;

--- a/src/pages/CreateProduct/components/Header/index.tsx
+++ b/src/pages/CreateProduct/components/Header/index.tsx
@@ -1,65 +1,18 @@
 import { Grid } from '@material-ui/core';
-import { currentStepAtom } from 'pages/CreateProduct/recoils';
-import { PAGE } from 'pages/CreateProduct/types';
+import { useGetStepContents } from 'pages/CreateProduct/hooks/useGetStepContents';
 import React from 'react';
-import { useRecoilValue } from 'recoil';
 import { Title, Contents } from 'styles/constants';
 
 import StepProgressBar from '../StepProgressBar';
 
 const Header = (): React.ReactElement => {
-  const currentStep = useRecoilValue(currentStepAtom);
-
-  const getStepContents = (): { title: string; detailContents: string } => {
-    const defaultContents = {
-      title: '💁 판매할 도안 선택하기',
-      detailContents:
-        '판매하고 싶은 도안을 아래에서 선택해주세요!\n여러 도안을 함께 묶어 세트로 판매해도 좋아요 😊\n많은 니터분들이 관심을 가질 수 있도록 구성해봐요!',
-    };
-
-    switch (currentStep) {
-      case PAGE.DESIGN:
-        return defaultContents;
-      case PAGE.PACKAGE:
-        return {
-          title: '📦 상품 구성하기',
-          detailContents:
-            '도안을 어떻게 판매할 것인지 상품을 구성해보세요!\n적절한 상품 구성은 더 많은 판매로 이어질 수 있어요! 🤭',
-        };
-      case PAGE.INTRODUCTION:
-        return {
-          title: '💬 상품에 대해 소개하기',
-          detailContents:
-            '이 상품에 대해 니터들에게 소개해주세요!\n도안을 따라 뜨개질을 하다보면 어떤 편물이 나오는지\n결과물을 공유해준다면,  더 많은 니터들이 믿고 구매할 수 있을거예요! 😉',
-        };
-      case PAGE.CONFIRM:
-        return {
-          title: '🔍 확인하기',
-          detailContents:
-            '다른 니터들에게 상품이 어떻게 노출될지 확인해보세요!\n수정되면 좋을 부분은 없는지 꼼꼼히 확인해봐요! 👀',
-        };
-      default:
-        return defaultContents;
-    }
-  };
-
-  const renderTitles = (): string => {
-    const { title } = getStepContents();
-
-    return title;
-  };
-
-  const renderContents = (): string => {
-    const { detailContents } = getStepContents();
-
-    return detailContents;
-  };
+  const { title, detailContents } = useGetStepContents();
 
   return (
     <Grid container>
       <Grid item xs={12} sm={8}>
-        <Title variant="h3">{renderTitles()}</Title>
-        <Contents>{renderContents()}</Contents>
+        <Title variant="h3">{title}</Title>
+        <Contents>{detailContents}</Contents>
       </Grid>
       <Grid item xs={12} sm={4}>
         <StepProgressBar />

--- a/src/pages/CreateProduct/components/StepProgressBar/index.tsx
+++ b/src/pages/CreateProduct/components/StepProgressBar/index.tsx
@@ -1,0 +1,14 @@
+import CommonStepProgressBar from 'components/CommonStepProgressBar';
+import React from 'react';
+import { useRecoilValue } from 'recoil';
+
+import { currentStepAtom } from '../../recoils';
+
+const StepProgressBar = (): React.ReactElement => {
+  const currentStep = useRecoilValue(currentStepAtom);
+  const steps = ['도안 선택', '상품 구성', '상품 소개', '최종 확인'];
+
+  return <CommonStepProgressBar steps={steps} currentStep={currentStep} />;
+};
+
+export default StepProgressBar;

--- a/src/pages/CreateProduct/hooks/useGetStepContents.ts
+++ b/src/pages/CreateProduct/hooks/useGetStepContents.ts
@@ -1,0 +1,47 @@
+import { useRecoilValue } from 'recoil';
+
+import { currentStepAtom } from '../recoils';
+import { PAGE } from '../types';
+
+export const useGetStepContents = (): {
+  title: string;
+  detailContents: string;
+} => {
+  const currentStep = useRecoilValue(currentStepAtom);
+
+  const stepContents = [
+    {
+      title: '💁 판매할 도안 선택하기',
+      detailContents:
+        '판매하고 싶은 도안을 아래에서 선택해주세요!\n여러 도안을 함께 묶어 세트로 판매해도 좋아요 😊\n많은 니터분들이 관심을 가질 수 있도록 구성해봐요!',
+    },
+    {
+      title: '📦 상품 구성하기',
+      detailContents:
+        '도안을 어떻게 판매할 것인지 상품을 구성해보세요!\n적절한 상품 구성은 더 많은 판매로 이어질 수 있어요! 🤭',
+    },
+    {
+      title: '💬 상품에 대해 소개하기',
+      detailContents:
+        '이 상품에 대해 니터들에게 소개해주세요!\n도안을 따라 뜨개질을 하다보면 어떤 편물이 나오는지\n결과물을 공유해준다면,  더 많은 니터들이 믿고 구매할 수 있을거예요! 😉',
+    },
+    {
+      title: '🔍 확인하기',
+      detailContents:
+        '다른 니터들에게 상품이 어떻게 노출될지 확인해보세요!\n수정되면 좋을 부분은 없는지 꼼꼼히 확인해봐요! 👀',
+    },
+  ];
+
+  switch (currentStep) {
+    case PAGE.DESIGN:
+      return stepContents[PAGE.DESIGN];
+    case PAGE.PACKAGE:
+      return stepContents[PAGE.PACKAGE];
+    case PAGE.INTRODUCTION:
+      return stepContents[PAGE.INTRODUCTION];
+    case PAGE.CONFIRM:
+      return stepContents[PAGE.CONFIRM];
+    default:
+      return stepContents[PAGE.DESIGN];
+  }
+};

--- a/src/pages/CreateProduct/index.tsx
+++ b/src/pages/CreateProduct/index.tsx
@@ -1,0 +1,39 @@
+import { Layout } from 'dumbs';
+import Package from 'pages/CreateProduct/Package';
+import React from 'react';
+import { useRecoilValue } from 'recoil';
+
+import Footer from './components/Footer';
+import Header from './components/Header';
+import { currentStepAtom } from './recoils';
+import { PAGE } from './types';
+
+const CreateProduct = (): React.ReactElement => {
+  const currentStep = useRecoilValue(currentStepAtom);
+
+  const renderContent = (): React.ReactElement => {
+    return <Package />;
+    // switch (currentStep) {
+    //   case PAGE.DESIGN:
+    //     return <div />;
+    //   case PAGE.PACKAGE:
+    //     return <Package />;
+    //   case PAGE.INTRODUCTION:
+    //     return <Package />;
+    //   case PAGE.CONFIRM:
+    //     return <Package />;
+    //   default:
+    //     return <div />;
+    // }
+  };
+
+  return (
+    <Layout>
+      <Header />
+      {renderContent()}
+      <Footer />
+    </Layout>
+  );
+};
+
+export default CreateProduct;

--- a/src/pages/CreateProduct/index.tsx
+++ b/src/pages/CreateProduct/index.tsx
@@ -12,19 +12,18 @@ const CreateProduct = (): React.ReactElement => {
   const currentStep = useRecoilValue(currentStepAtom);
 
   const renderContent = (): React.ReactElement => {
-    return <Package />;
-    // switch (currentStep) {
-    //   case PAGE.DESIGN:
-    //     return <div />;
-    //   case PAGE.PACKAGE:
-    //     return <Package />;
-    //   case PAGE.INTRODUCTION:
-    //     return <Package />;
-    //   case PAGE.CONFIRM:
-    //     return <Package />;
-    //   default:
-    //     return <div />;
-    // }
+    switch (currentStep) {
+      case PAGE.DESIGN:
+        return <div />;
+      case PAGE.PACKAGE:
+        return <Package />;
+      case PAGE.INTRODUCTION:
+        return <div />;
+      case PAGE.CONFIRM:
+        return <div />;
+      default:
+        return <div />;
+    }
   };
 
   return (

--- a/src/pages/CreateProduct/recoils.ts
+++ b/src/pages/CreateProduct/recoils.ts
@@ -1,0 +1,22 @@
+import { atom } from 'recoil';
+
+import { PAGE, PAGE_TYPE, ProductInput } from './types';
+
+export const currentStepAtom = atom<PAGE_TYPE>({
+  key: 'currentStep',
+  default: PAGE.DESIGN,
+});
+
+export const currentProductInputAtom = atom<ProductInput>({
+  key: 'currentProductInput',
+  default: {
+    name: '',
+    fullPrice: 0,
+    discountPrice: 0,
+    representativeImageUrl: '',
+    specifiedSalesStartDate: null,
+    specifiedSalesEndDate: null,
+    tags: [''],
+    designIds: [],
+  },
+});

--- a/src/pages/CreateProduct/recoils.ts
+++ b/src/pages/CreateProduct/recoils.ts
@@ -16,7 +16,7 @@ export const currentProductInputAtom = atom<ProductInput>({
     representativeImageUrl: '',
     specifiedSalesStartDate: null,
     specifiedSalesEndDate: null,
-    tags: [''],
+    tags: '',
     designIds: [],
   },
 });

--- a/src/pages/CreateProduct/types.ts
+++ b/src/pages/CreateProduct/types.ts
@@ -12,8 +12,8 @@ export type ProductInput = {
   fullPrice: number;
   discountPrice: number;
   representativeImageUrl: string;
-  specifiedSalesStartDate: string | null;
-  specifiedSalesEndDate: string | null;
-  tags: string[];
+  specifiedSalesStartDate?: string | null;
+  specifiedSalesEndDate?: string | null;
+  tags: string;
   designIds: number[];
 };

--- a/src/pages/CreateProduct/types.ts
+++ b/src/pages/CreateProduct/types.ts
@@ -1,0 +1,19 @@
+export const PAGE = {
+  DESIGN: 0,
+  PACKAGE: 1,
+  INTRODUCTION: 2,
+  CONFIRM: 3,
+} as const;
+
+export type PAGE_TYPE = typeof PAGE[keyof typeof PAGE];
+
+export type ProductInput = {
+  name: string;
+  fullPrice: number;
+  discountPrice: number;
+  representativeImageUrl: string;
+  specifiedSalesStartDate: string | null;
+  specifiedSalesEndDate: string | null;
+  tags: string[];
+  designIds: number[];
+};

--- a/src/routers/MyInformationRouter/index.tsx
+++ b/src/routers/MyInformationRouter/index.tsx
@@ -1,9 +1,11 @@
 import {
   MY_INFORMATION_PROFILE_PATH,
   MY_INFORMATION_CREATE_DESIGN_PATH,
+  MY_INFORMATION_CREATE_PRODUCT_PATH,
 } from 'constants/path';
 
 import CreateDesign from 'pages/CreateDesign';
+import CreateProduct from 'pages/CreateProduct';
 import Error404 from 'pages/Error404';
 import MyInformation from 'pages/MyInformation';
 import React from 'react';
@@ -23,6 +25,13 @@ const MyInformationRouter = (): React.ReactElement => {
       <ProtectedRoute
         path={MY_INFORMATION_CREATE_DESIGN_PATH}
         component={CreateDesign}
+        exact
+        strict
+        sensitive
+      />
+      <ProtectedRoute
+        path={MY_INFORMATION_CREATE_PRODUCT_PATH}
+        component={CreateProduct}
         exact
         strict
         sensitive

--- a/src/styles/constants.ts
+++ b/src/styles/constants.ts
@@ -23,3 +23,9 @@ export const Title = styled(Typography)`
 export const Contents = styled(Typography)`
   white-space: pre-line;
 `;
+
+export const FooterContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: ${theme.spacing(6, 0, 4)};
+`;

--- a/src/styles/constants.ts
+++ b/src/styles/constants.ts
@@ -1,4 +1,5 @@
-import { css } from 'styled-components';
+import { Typography } from '@material-ui/core';
+import styled, { css } from 'styled-components';
 import { theme } from 'themes';
 
 export const flexCenterAlign = css`
@@ -13,3 +14,12 @@ export const flexVerticalAlign = css`
 `;
 
 export const defaultShadow = theme.shadows[8];
+
+export const Title = styled(Typography)`
+  margin-bottom: ${theme.spacing(2)};
+  font-weight: 600;
+`;
+
+export const Contents = styled(Typography)`
+  white-space: pre-line;
+`;

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs';
 
-type DateTemplate = 'YYYY.MM.DD';
+type DateTemplate = 'YYYY.MM.DD' | 'YYYY-MM-DD hh:mm:ss';
 
 export const formatDate = (
   date: string | Date,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1455,22 +1455,17 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
-"@date-io/core@1.x":
+"@date-io/core@1.x", "@date-io/core@^1.3.13":
   version "1.3.13"
   resolved "https://registry.yarnpkg.com/@date-io/core/-/core-1.3.13.tgz#90c71da493f20204b7a972929cc5c482d078b3fa"
   integrity sha512-AlEKV7TxjeK+jxWVKcCFrfYAk8spX9aCyiToFIiLPtfQbsjmRGLIhb5VZgptQcJdHtLXo7+m0DuurwFgUToQuA==
 
-"@date-io/core@^2.11.0":
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/@date-io/core/-/core-2.11.0.tgz#28580cda1c8228ab2c7ed6aee673ef0495f913e6"
-  integrity sha512-DvPBnNoeuLaoSJZaxgpu54qzRhRKjSYVyQjhznTFrllKuDpm0sDFjHo6lvNLCM/cfMx2gb2PM2zY2kc9C8nmuw==
-
-"@date-io/date-fns@^2.11.0":
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/@date-io/date-fns/-/date-fns-2.11.0.tgz#142fbf954eda7ad66514af7a2802d78c4ea40053"
-  integrity sha512-mPQ71plBeFrArvBSHtjWMHXA89IUbZ6kuo2dsjlRC/1uNOybo91spIb+wTu03NxKTl8ut07s0jJ9svF71afpRg==
+"@date-io/date-fns@1.3.13":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@date-io/date-fns/-/date-fns-1.3.13.tgz#7798844041640ab393f7e21a7769a65d672f4735"
+  integrity sha512-yXxGzcRUPcogiMj58wVgFjc9qUYrCnnU9eLcyNbsQCmae4jPuZCDoIBR21j8ZURsM7GRtU62VOw5yNd4dDHunA==
   dependencies:
-    "@date-io/core" "^2.11.0"
+    "@date-io/core" "^1.3.13"
 
 "@draft-js-plugins/buttons@^4.0.0", "@draft-js-plugins/buttons@^4.1.0":
   version "4.1.0"
@@ -6312,6 +6307,11 @@ data-urls@^2.0.0:
     abab "^2.0.3"
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
+
+date-fns@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.24.0.tgz#7d86dc0d93c87b76b63d213b4413337cfd1c105d"
+  integrity sha512-6ujwvwgPID6zbI0o7UbURi2vlLDR9uP26+tW6Lg+Ji3w7dd0i3DOcjcClLjLPranT60SSEFBwdSyYwn/ZkPIuw==
 
 dayjs@^1.10.6:
   version "1.10.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12999,6 +12999,11 @@ react-hotkeys@2.0.0:
   dependencies:
     prop-types "^15.6.1"
 
+react-images-uploading@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/react-images-uploading/-/react-images-uploading-3.1.3.tgz#1cd1894f801e7ecba28b65f713980aa0c130722f"
+  integrity sha512-Ak9uaHTsCM6JboEo5JU0esx13IxQuZ1ZxgWgdqVIsK5ZSty88lcf1CTxpMTZFZVVuIxWOm9VsRvs6cyMUDTWeg==
+
 react-infinite-scroll-component@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/react-infinite-scroll-component/-/react-infinite-scroll-component-6.1.0.tgz#7e511e7aa0f728ac3e51f64a38a6079ac522407f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1455,6 +1455,23 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
+"@date-io/core@1.x":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@date-io/core/-/core-1.3.13.tgz#90c71da493f20204b7a972929cc5c482d078b3fa"
+  integrity sha512-AlEKV7TxjeK+jxWVKcCFrfYAk8spX9aCyiToFIiLPtfQbsjmRGLIhb5VZgptQcJdHtLXo7+m0DuurwFgUToQuA==
+
+"@date-io/core@^2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@date-io/core/-/core-2.11.0.tgz#28580cda1c8228ab2c7ed6aee673ef0495f913e6"
+  integrity sha512-DvPBnNoeuLaoSJZaxgpu54qzRhRKjSYVyQjhznTFrllKuDpm0sDFjHo6lvNLCM/cfMx2gb2PM2zY2kc9C8nmuw==
+
+"@date-io/date-fns@^2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@date-io/date-fns/-/date-fns-2.11.0.tgz#142fbf954eda7ad66514af7a2802d78c4ea40053"
+  integrity sha512-mPQ71plBeFrArvBSHtjWMHXA89IUbZ6kuo2dsjlRC/1uNOybo91spIb+wTu03NxKTl8ut07s0jJ9svF71afpRg==
+  dependencies:
+    "@date-io/core" "^2.11.0"
+
 "@draft-js-plugins/buttons@^4.0.0", "@draft-js-plugins/buttons@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@draft-js-plugins/buttons/-/buttons-4.1.0.tgz#8a330fc93aa302caac9df9f888821ddacc975459"
@@ -2237,10 +2254,22 @@
     prop-types "^15.7.2"
     react-is "^16.8.0 || ^17.0.0"
 
-"@material-ui/styles@^4.11.3":
-  version "4.11.3"
-  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.3.tgz#1b8d97775a4a643b53478c895e3f2a464e8916f2"
-  integrity sha512-HzVzCG+PpgUGMUYEJ2rTEmQYeonGh41BYfILNFb/1ueqma+p1meSdu4RX6NjxYBMhf7k+jgfHFTTz+L1SXL/Zg==
+"@material-ui/pickers@^3.3.10":
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/@material-ui/pickers/-/pickers-3.3.10.tgz#f1b0f963348cc191645ef0bdeff7a67c6aa25485"
+  integrity sha512-hS4pxwn1ZGXVkmgD4tpFpaumUaAg2ZzbTrxltfC5yPw4BJV+mGkfnQOB4VpWEYZw2jv65Z0wLwDE/piQiPPZ3w==
+  dependencies:
+    "@babel/runtime" "^7.6.0"
+    "@date-io/core" "1.x"
+    "@types/styled-jsx" "^2.2.8"
+    clsx "^1.0.2"
+    react-transition-group "^4.0.0"
+    rifm "^0.7.0"
+
+"@material-ui/styles@^4.11.4":
+  version "4.11.4"
+  resolved "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.4.tgz"
+  integrity sha512-KNTIZcnj/zprG5LW0Sao7zw+yG3O35pviHzejMdcSGCdWbiO8qzRgOYL8JAxAsWBKOKYwVZxXtHWaB5T2Kvxew==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@emotion/hash" "^0.8.0"


### PR DESCRIPTION
## PR 제안 사유
- 상품 등록 절차 중 상품 구성하기 페이지를 추가합니다.
- 상품 구성하기 api `/product/package` 를 연동합니다.

Resolve #112 

## 주요 변경 기록
- `/my/products/create` 라우터 추가
- `/product/package` api 연동

## 기타 질문 및 특이 사항
대표 이미지 업로드하는 부분에 `FileUploader`가 들어갈거라 추후 작업이 필요합니당.
지금은 그냥 아무 업로더 하나 넣어뒀어요 ~
![image](https://user-images.githubusercontent.com/43168524/136495323-20cf598e-6ba9-48dd-bd9d-2a8b21269c86.png)
