### PR TITLE
[Feat] 도안 생성 시 가격 필드 추가

### DIFF
--- a/src/pages/CreateDesign/Outline/index.tsx
+++ b/src/pages/CreateDesign/Outline/index.tsx
@@ -33,7 +33,8 @@ const Outline = (): React.ReactElement => {
 
   const [outlineInput, setOutlineInput] = useRecoilState(outlineInputAtom);
 
-  const { designType, patternType, stitches, rows, needle } = outlineInput;
+  const { price, designType, patternType, stitches, rows, needle } =
+    outlineInput;
 
   const isInvalidOutlineValue = useInvalidOutline();
 
@@ -78,6 +79,17 @@ const Outline = (): React.ReactElement => {
 
   return (
     <Grid container>
+      <Row item xs={12}>
+        <InputWithLabel
+          id="price"
+          type="number"
+          variant="h5"
+          label="도안 가격"
+          value={price}
+          onChange={(event) => handleInputChange(event, 'price', true)}
+          isRequired
+        />
+      </Row>
       <Row item xs={12} sm={6}>
         <RequiredSelect
           id="design-type"

--- a/src/pages/CreateDesign/atom.ts
+++ b/src/pages/CreateDesign/atom.ts
@@ -11,7 +11,7 @@ export type CoverInput = Pick<
 
 export type OutlineInput = Pick<
   DesignInput,
-  'designType' | 'patternType' | 'stitches' | 'rows' | 'needle'
+  'price' | 'designType' | 'patternType' | 'stitches' | 'rows' | 'needle'
 >;
 
 export type OptionalOutlineInput = Pick<
@@ -43,6 +43,7 @@ export const coverImageAtom = atom<ImageInformation | undefined>({
 export const outlineInputAtom = atom<OutlineInput>({
   key: 'outlineInputAtom',
   default: {
+    price: 0,
     designType: DESIGN.SWEATER,
     patternType: PATTERN.TEXT,
     stitches: 0,

--- a/src/pages/CreateDesign/components/Footer/hooks/useSaveDesign.ts
+++ b/src/pages/CreateDesign/components/Footer/hooks/useSaveDesign.ts
@@ -14,9 +14,14 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 
-export const useSaveDesign = (): (() => void) | undefined => {
+type SaveDesign = {
+  saveDesign: (coverImageUrl: string) => void;
+  uploadFile: (() => void) | undefined;
+};
+
+export const useSaveDesign = (): SaveDesign => {
   const { name, description } = useRecoilValue(coverInputAtom);
-  const { designType, patternType, stitches, rows, needle } =
+  const { price, designType, patternType, stitches, rows, needle } =
     useRecoilValue(outlineInputAtom);
   const { size, yarn, extra, targetLevel, techniques } = useRecoilValue(
     optionalOutlineInputAtom,
@@ -38,7 +43,7 @@ export const useSaveDesign = (): (() => void) | undefined => {
   });
 
   const { mutate } = usePost({
-    pathname: '/design',
+    pathname: '/designs',
     onSuccess: () => navigate(MY_INFORMATION_ROUTER_ROOT),
   });
 
@@ -67,6 +72,7 @@ export const useSaveDesign = (): (() => void) | undefined => {
       needle,
       yarn,
       extra,
+      price,
       description,
       target_level: targetLevel,
       pattern,
@@ -84,5 +90,5 @@ export const useSaveDesign = (): (() => void) | undefined => {
     }
   }, [uploadResults]);
 
-  return uploadFile;
+  return { saveDesign, uploadFile };
 };

--- a/src/pages/CreateDesign/components/Footer/hooks/useStepController.ts
+++ b/src/pages/CreateDesign/components/Footer/hooks/useStepController.ts
@@ -20,7 +20,7 @@ export const useStepController = (): StepController => {
   const [currentStep, setCurrentStep] = useRecoilState(currentStepAtom);
   const { name, coverImageUrl } = useRecoilValue(coverInputAtom);
   const isInvalidOutlineValue = useInvalidOutline();
-  const saveDesign = useSaveDesign();
+  const { saveDesign } = useSaveDesign();
 
   const onPreviousClick = (): void => {
     switch (currentStep) {
@@ -50,7 +50,7 @@ export const useStepController = (): StepController => {
         setCurrentStep(PAGE.REVIEW);
         break;
       case PAGE.REVIEW:
-        saveDesign?.();
+        saveDesign(coverImageUrl);
         break;
       default:
         break;

--- a/src/pages/CreateDesign/components/Header/index.tsx
+++ b/src/pages/CreateDesign/components/Header/index.tsx
@@ -9,12 +9,13 @@ import { Contents, Title } from './Header.css';
 
 const Header = (): React.ReactElement => {
   const currentStep = useRecoilValue(currentStepAtom);
+  const { title, detailContents } = renderStepContents(currentStep);
 
   return (
     <Grid container>
       <Grid item xs={12} sm={8}>
-        <Title variant="h3">✏️ 새로운 도안 작성</Title>
-        <Contents>{renderStepContents(currentStep)}</Contents>
+        <Title variant="h3">{title}</Title>
+        <Contents>{detailContents}</Contents>
       </Grid>
       <Grid item xs={12} sm={4}>
         <StepProgressBar />

--- a/src/pages/CreateDesign/types.ts
+++ b/src/pages/CreateDesign/types.ts
@@ -72,6 +72,7 @@ export type PostDesignInput = {
   needle: string;
   yarn: string;
   extra?: string;
+  price: number;
   pattern: string;
 };
 


### PR DESCRIPTION
## PR 제안 사유

<!--
아래 키워드 중 하나를 붙여 이슈를 자동으로 종료할 수 있도록 해주세요.
- Close
- Closes
- Closed
- Fix
- Fixes
- Fixed
- Resolve
- Resolves
- Resolved
-->

Resolve #1vyej1g

<!--
왜 이 PR을 제안하게 되었는지 간략하게 적어주세요.
이슈 내용만으로 설명이 된다면 생략 가능합니다.
-->

## 주요 변경 기록
- 도안 생성 시 가격을 입력하는 필드 추가
- API 호출 시 가격 param 추가

<!--
간단하게라도 적어주세요.
변경된 자세한 내용을 적어주셔도 좋습니다.
-->

## Code review
- [Postman](https://k-roffle.postman.co/workspace/Knitting~3f2a90fd-ecbf-4539-886a-e78bc7bb8e45/request/18454204-4d1fd8fd-7e63-4936-a36c-45a7f4497a38) 보니까 API 엔드포인트가 `/designs` 로 되어있어 엔드포인트 변경했습니다.
- cd880f4 이 커밋은 main 브랜치 실행 시 도안 작성 단계별 내용 뿌려주는 부분에 문제가 있어 픽스해준 커밋입니다.

### Code review 에서 중점적으로 봐야하는 부분

<!-- 생략 가능합니다. -->

## Design review

### Design review 에서 중점적으로 봐야하는 부분 / 스크린샷
<img width="1446" alt="image" src="https://user-images.githubusercontent.com/43168524/153754374-602b03a3-33b8-4e49-a4fe-303e8d789b7a.png">

<!-- 생략 가능합니다. -->

## 기타 질문 및 특이 사항
도안 작성 마지막 단계인 확인하기 페이지는 나중에 pdf로 구워서 pdf를 노출하는 영역인가유 ?
이 부분에도 가격 필드를 추가할까 하다가 우선 스킵 했습니다 !!
<img width="1428" alt="image" src="https://user-images.githubusercontent.com/43168524/153754521-18bb54bf-c6a9-444d-8802-cc0046153e55.png">


<!-- 생략 가능합니다. -->
