### PR TITLE
[Feat] 도안 임시저장 기능 추가

### DIFF
--- a/src/hooks/useGet.ts
+++ b/src/hooks/useGet.ts
@@ -1,6 +1,6 @@
 import { useCommonSnackbar } from 'knitting/components/CommonSnackbar/useCommonSnackbar';
 import { GENERAL_ERROR } from 'knitting/constants/errors';
-import { RequestParam } from 'knitting/utils/requestType';
+import { QueryRequestParam } from 'knitting/utils/requestType';
 import { getRequest } from 'knitting/utils/requests';
 import { UseQueryResult } from 'react-query/types/react/types';
 
@@ -15,7 +15,7 @@ export const useGet = <
   pathname,
   errorMessage = GENERAL_ERROR,
   onSuccess,
-}: RequestParam): UseQueryResult<TData, TError> => {
+}: QueryRequestParam<TData>): UseQueryResult<TData, TError> => {
   const [showError, setShowError] = useState<boolean>(false);
 
   useCommonSnackbar({

--- a/src/hooks/usePost.ts
+++ b/src/hooks/usePost.ts
@@ -1,17 +1,25 @@
 import { useCommonSnackbar } from 'knitting/components/CommonSnackbar/useCommonSnackbar';
 import { GENERAL_ERROR, NETWORK_ERROR } from 'knitting/constants/errors';
-import { RequestParam } from 'knitting/utils/requestType';
+import { MutateRequestParam } from 'knitting/utils/requestType';
 import { postRequest } from 'knitting/utils/requests';
 
 import { useState } from 'react';
 import { useMutation, UseMutationResult } from 'react-query';
 
-export const usePost = ({
+type TError = {
+  response: unknown;
+};
+
+export const usePost = <TData = unknown, TVariables = void>({
   pathname,
   errorMessage = GENERAL_ERROR,
   onSuccess,
   onError,
-}: RequestParam): UseMutationResult<void, unknown> => {
+}: MutateRequestParam<TData, TError, TVariables>): UseMutationResult<
+  TData,
+  TError,
+  TVariables
+> => {
   const [postErrorMessage, setPostErrorMessage] = useState<string>();
 
   useCommonSnackbar({
@@ -29,7 +37,7 @@ export const usePost = ({
   };
 
   return useMutation(pathname, (postData) => postRequest(pathname, postData), {
-    onSuccess: () => onSuccess?.(),
+    onSuccess,
     onError: handleError,
   });
 };

--- a/src/pages/CreateDesign/atom.ts
+++ b/src/pages/CreateDesign/atom.ts
@@ -84,3 +84,8 @@ export const editorStateAtom = atom<EditorState>({
   key: 'editorState',
   default: EditorState.createEmpty(),
 });
+
+export const draftIdAtom = atom<number | null>({
+  key: 'draftId',
+  default: null,
+});

--- a/src/pages/CreateDesign/components/Footer/hooks/useSaveDesign.ts
+++ b/src/pages/CreateDesign/components/Footer/hooks/useSaveDesign.ts
@@ -70,7 +70,7 @@ export const useSaveDesign = (): SaveDesign => {
     dependencies: [isSuccess],
   });
 
-  const getDesignData = (): PostDesignInput => {
+  const getDesignData = (): Omit<PostDesignInput, 'draft_id'> => {
     const pattern = `${JSON.stringify(
       convertToRaw(editorState.getCurrentContent()),
     )}`;
@@ -111,7 +111,10 @@ export const useSaveDesign = (): SaveDesign => {
   };
 
   const saveDesign = (): void => {
-    saveMutate(getDesignData());
+    saveMutate({
+      ...getDesignData(),
+      draft_id: draftId,
+    });
   };
 
   useEffect(() => {

--- a/src/pages/CreateDesign/components/Footer/hooks/useStepController.ts
+++ b/src/pages/CreateDesign/components/Footer/hooks/useStepController.ts
@@ -18,10 +18,10 @@ type StepController = {
 
 export const useStepController = (): StepController => {
   const [currentStep, setCurrentStep] = useRecoilState(currentStepAtom);
-  const { coverImageUrl } = useRecoilValue(coverInputAtom);
+  const { name, coverImageUrl } = useRecoilValue(coverInputAtom);
   const [stepValidations, setStepValidations] =
     useRecoilState(stepValidationsAtom);
-  const { saveDesign } = useSaveDesign();
+  const { draftDesign, saveDesign } = useSaveDesign();
 
   const onPreviousClick = (): void => {
     switch (currentStep) {
@@ -42,16 +42,19 @@ export const useStepController = (): StepController => {
   const onNextClick = (): void => {
     switch (currentStep) {
       case PAGE.COVER:
+        draftDesign();
         setCurrentStep(PAGE.OUTLINE);
         break;
       case PAGE.OUTLINE:
+        draftDesign();
         setCurrentStep(PAGE.PATTERN);
         break;
       case PAGE.PATTERN:
+        draftDesign();
         setCurrentStep(PAGE.REVIEW);
         break;
       case PAGE.REVIEW:
-        saveDesign(coverImageUrl);
+        saveDesign();
         break;
       default:
         break;

--- a/src/pages/CreateDesign/components/Footer/hooks/useStepController.ts
+++ b/src/pages/CreateDesign/components/Footer/hooks/useStepController.ts
@@ -40,17 +40,16 @@ export const useStepController = (): StepController => {
   };
 
   const onNextClick = (): void => {
+    draftDesign();
+
     switch (currentStep) {
       case PAGE.COVER:
-        draftDesign();
         setCurrentStep(PAGE.OUTLINE);
         break;
       case PAGE.OUTLINE:
-        draftDesign();
         setCurrentStep(PAGE.PATTERN);
         break;
       case PAGE.PATTERN:
-        draftDesign();
         setCurrentStep(PAGE.REVIEW);
         break;
       case PAGE.REVIEW:

--- a/src/pages/CreateDesign/types.ts
+++ b/src/pages/CreateDesign/types.ts
@@ -76,4 +76,10 @@ export type PostDesignInput = {
   pattern: string;
 };
 
+export type PostDraftDesign = {
+  id: number | null;
+  design_id: number | null;
+  value: string;
+};
+
 export type DesignInput = SnakeToCamelCase<PostDesignInput>;

--- a/src/pages/CreateDesign/types.ts
+++ b/src/pages/CreateDesign/types.ts
@@ -74,6 +74,7 @@ export type PostDesignInput = {
   extra?: string;
   price: number;
   pattern: string;
+  draft_id: number | null;
 };
 
 export type PostDraftDesign = {
@@ -82,4 +83,4 @@ export type PostDraftDesign = {
   value: string;
 };
 
-export type DesignInput = SnakeToCamelCase<PostDesignInput>;
+export type DesignInput = Omit<SnakeToCamelCase<PostDesignInput>, 'draftId'>;

--- a/src/pages/CreateProduct/components/Footer/hooks/useSaveProduct.ts
+++ b/src/pages/CreateProduct/components/Footer/hooks/useSaveProduct.ts
@@ -5,7 +5,7 @@ import {
   currentProductInputAtom,
   currentStepAtom,
 } from 'knitting/pages/CreateProduct/recoils';
-import { PAGE } from 'knitting/pages/CreateProduct/types';
+import { PAGE, PostProductInput } from 'knitting/pages/CreateProduct/types';
 import { splitText } from 'knitting/utils/splitText';
 
 import { useRecoilValue, useSetRecoilState } from 'recoil';
@@ -37,7 +37,7 @@ export const useSaveProduct = (): SaveProduct => {
     setCurrentStep(PAGE.INTRODUCTION);
   };
 
-  const { data, mutate } = usePost({
+  const { data, mutate } = usePost<number, PostProductInput>({
     pathname: '/product/package',
     errorMessage: FAILED_TO_SAVE_PRODUCT,
     onSuccess,

--- a/src/pages/CreateProduct/components/Footer/hooks/useStartSale.ts
+++ b/src/pages/CreateProduct/components/Footer/hooks/useStartSale.ts
@@ -13,7 +13,7 @@ export const useStartSale = (): StartSale => {
   const currentProductId = useRecoilValue(currentProductIdAtom);
   const navigate = useNavigate();
 
-  const { mutate } = usePost({
+  const { mutate } = usePost<number, { id?: number }>({
     pathname: '/product',
   });
 

--- a/src/pages/CreateProduct/types.ts
+++ b/src/pages/CreateProduct/types.ts
@@ -1,3 +1,5 @@
+import { SnakeToCamelCase } from 'knitting/utils/types';
+
 export const PAGE = {
   DESIGN: 0,
   PACKAGE: 1,
@@ -11,13 +13,17 @@ export type ProductId = {
   id: number;
 };
 
-export type ProductInput = {
+export type PostProductInput = {
   name: string;
-  fullPrice: number;
-  discountPrice: number;
-  representativeImageUrl: string;
-  specifiedSalesStartDate?: string | null;
-  specifiedSalesEndDate?: string | null;
+  design_ids: number[];
+  full_price: number;
+  discount_price: number;
+  representative_image_url: string;
+  specified_sales_start_date: string | null;
+  specified_sales_end_date: string | null;
+  tags: string[];
+};
+
+export type ProductInput = Omit<SnakeToCamelCase<PostProductInput>, 'tags'> & {
   tags: string;
-  designIds: number[];
 };

--- a/src/utils/requestType.ts
+++ b/src/utils/requestType.ts
@@ -1,3 +1,5 @@
+import { MutateOptions, QueryObserverOptions } from 'react-query';
+
 export const DEFAULT_LIST_LENGTH = 10;
 
 export type Meta = {
@@ -6,12 +8,18 @@ export type Meta = {
 
 export type ListResponse<T> = { payload: T[]; meta: Meta };
 export type ObjectResponse<T> = { payload: T; meta: Meta };
-export type RequestParam = {
+type RequestParam = {
   pathname: string;
   errorMessage?: string;
-
-  onSuccess?: () => void;
   onError?: () => void;
   isError?: boolean;
   isLoading?: boolean;
+};
+
+export type MutateRequestParam<TData, TError, TVariables> = RequestParam & {
+  onSuccess?: MutateOptions<TData, TError, TVariables>['onSuccess'];
+};
+
+export type QueryRequestParam<TData> = RequestParam & {
+  onSuccess?: QueryObserverOptions<TData>['onSuccess'];
 };

--- a/src/utils/requests.ts
+++ b/src/utils/requests.ts
@@ -98,11 +98,11 @@ export const getRequest = async <T extends ListResponse<unknown>>(
   return data;
 };
 
-export const postRequest = async <T>(
+export const postRequest = async <TVariables, TData>(
   pathname: string,
-  postData: T,
+  postData: TVariables,
   useCurrentToken = true,
-): Promise<void> => {
+): Promise<TData> => {
   const { data } = await request({
     pathname,
     method: 'post',


### PR DESCRIPTION
## PR 제안 사유
- 도안 작성 시 다음 단계로 넘어갈 때마다 임시저장하는 기능을 추가합니다.
- 도안을 생성할 때 임시저장 내역을 보내주도록 합니다.

Resolves #[1vrmb0y](https://app.clickup.com/t/1vrmb0y), #[1vrmb2g](https://app.clickup.com/t/1vrmb2g)

<!--
왜 이 PR을 제안하게 되었는지 간략하게 적어주세요.
이슈 내용만으로 설명이 된다면 생략 가능합니다.
-->

## 주요 변경 기록
- 도안 작성 시 임시저장
    - `/designs/draft` API 연동
    - https://github.com/k-roffle/knitting-service/pull/147
- 도안 생성 시 임시저장 내역 보내주기
    - `/designs` API에 `draft_id` 값 추가
    - https://github.com/k-roffle/knitting-service/pull/148
<!--
간단하게라도 적어주세요.
변경된 자세한 내용을 적어주셔도 좋습니다.
-->

## Code review

### Code review 에서 중점적으로 봐야하는 부분

<!-- 생략 가능합니다. -->

## Design review

### Design review 에서 중점적으로 봐야하는 부분 / 스크린샷

<!-- 생략 가능합니다. -->

## 기타 질문 및 특이 사항

<!-- 생략 가능합니다. -->
