### PR TITLE
[Feat] 상품 구성하기 화면에서 가격 아코디언 추가

### DIFF
--- a/src/dumbs/Accordion/Accordion.css.ts
+++ b/src/dumbs/Accordion/Accordion.css.ts
@@ -1,0 +1,18 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import { Accordion } from '@mui/material';
+
+export const StyledAccordion = styled(Accordion)`
+  &::before {
+    content: none;
+  }
+  ${({ theme }) => css`
+    background-color: ${theme.palette.grey[200]};
+    border-radius: ${theme.spacing(1)};
+    &:last-of-type {
+      border-radius: ${theme.spacing(1)};
+    }
+  `}
+  display: inline-block;
+  box-shadow: none;
+`;

--- a/src/dumbs/Accordion/index.tsx
+++ b/src/dumbs/Accordion/index.tsx
@@ -1,0 +1,29 @@
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { AccordionSummary, AccordionDetails, Typography } from '@mui/material';
+import React from 'react';
+
+import { StyledAccordion } from './Accordion.css';
+
+type P = {
+  summary: string;
+  detailElements: React.ReactElement[];
+};
+
+const Accordion = ({ summary, detailElements }: P): React.ReactElement => (
+  <StyledAccordion>
+    <AccordionSummary
+      expandIcon={<ExpandMoreIcon />}
+      aria-controls="panel1a-content"
+      id="panel1a-header"
+    >
+      <Typography>{summary}</Typography>
+    </AccordionSummary>
+    {detailElements.length && (
+      <AccordionDetails>
+        {detailElements.map((element) => element)}
+      </AccordionDetails>
+    )}
+  </StyledAccordion>
+);
+
+export default Accordion;

--- a/src/pages/CreateProduct/Package/Package.css.ts
+++ b/src/pages/CreateProduct/Package/Package.css.ts
@@ -70,3 +70,18 @@ export const ImagePreview = styled.img`
     width: ${theme.spacing(20)};
   `}
 `;
+
+export const AccordionDetail = styled.div`
+  display: flex;
+`;
+
+export const Name = styled(Typography)`
+  width: ${({ theme }) => theme.spacing(25)};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const Price = styled(Typography)`
+  margin-left: ${({ theme }) => theme.spacing(4)};
+`;

--- a/src/pages/CreateProduct/Package/Package.css.ts
+++ b/src/pages/CreateProduct/Package/Package.css.ts
@@ -1,0 +1,72 @@
+import styled from '@emotion/styled';
+import { Close } from '@mui/icons-material';
+import { Grid, Input, Typography, css } from '@mui/material';
+
+export const Row = styled(Grid)`
+  margin-top: ${({ theme }) => theme.spacing(2)};
+`;
+
+export const FullWidthInput = styled(Input)`
+  width: 100%;
+`;
+
+export const Rate = styled.span`
+  ${({ theme }) => css`
+    color: ${theme.palette.primary.main};
+    margin-left: ${theme.spacing(2)};
+    font-size: ${theme.spacing(1.75)};
+  `}
+`;
+
+export const SalesDateInfo = styled(Typography)<{
+  invalid?: boolean;
+}>`
+  ${({ theme, invalid }) => css`
+    margin-top: ${theme.spacing(1)};
+    color: ${invalid ? '#ff0000' : '#808080'};
+  `}
+`;
+
+export const Wave = styled.span`
+  margin: 0 ${({ theme }) => theme.spacing(1)};
+`;
+
+export const ImageWrapper = styled(Grid)`
+  margin: ${({ theme }) => theme.spacing(-1)};
+`;
+
+export const ImageItem = styled(Grid)`
+  margin: ${({ theme }) => theme.spacing(1)};
+  position: relative;
+`;
+
+export const CloseButton = styled(Close)`
+  position: absolute;
+  ${({ theme }) => css`
+    top: ${theme.spacing(1)};
+    right: ${theme.spacing(1)};
+  `}
+`;
+
+export const ImageUploader = styled.button`
+  ${({ theme }) => css`
+    margin: ${theme.spacing(1)};
+    border-radius: ${theme.spacing(5)};
+    border: ${theme.spacing(0.25)} solid ${theme.palette.grey[200]};
+    width: ${theme.spacing(20)};
+    height: ${theme.spacing(20)};
+  `}
+  background: none;
+  color: inherit;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  outline: inherit;
+`;
+
+export const ImagePreview = styled.img`
+  ${({ theme }) => css`
+    border-radius: ${theme.spacing(5)};
+    width: ${theme.spacing(20)};
+  `}
+`;

--- a/src/pages/CreateProduct/Package/index.tsx
+++ b/src/pages/CreateProduct/Package/index.tsx
@@ -1,17 +1,12 @@
 import { FormLabel, InputWithLabel, RequiredMark } from 'knitting/dumbs';
 import InlineInput from 'knitting/dumbs/InlineInput';
-import { theme } from 'knitting/themes';
 import { formatDate } from 'knitting/utils/format';
 
-import styled from '@emotion/styled';
-import { Close } from '@mui/icons-material';
 import AdapterDateFns from '@mui/lab/AdapterDateFns';
 import DatePicker from '@mui/lab/DatePicker';
 import LocalizationProvider from '@mui/lab/LocalizationProvider';
 import {
   Grid,
-  Input,
-  Typography,
   InputProps,
   InputAdornment,
   TextField,
@@ -25,65 +20,18 @@ import { useRecoilState } from 'recoil';
 
 import { currentProductInputAtom } from '../recoils';
 
-const Row = styled(Grid)`
-  margin-top: ${theme.spacing(2)};
-`;
-
-const FullWidthInput = styled(Input)`
-  width: 100%;
-`;
-
-const Rate = styled.span`
-  color: ${theme.palette.primary.main};
-  margin-left: ${theme.spacing(2)};
-  font-size: ${theme.spacing(1.75)};
-`;
-
-const SalesDateInfo = styled(Typography)<{
-  invalid?: boolean;
-}>`
-  margin-top: ${theme.spacing(1)};
-  color: ${({ invalid }) => (invalid ? '#ff0000' : '#808080')};
-`;
-
-const Wave = styled.span`
-  margin: 0 ${theme.spacing(1)};
-`;
-
-const ImageWrapper = styled(Grid)`
-  margin: ${theme.spacing(-1)};
-`;
-
-const ImageItem = styled(Grid)`
-  margin: ${theme.spacing(1)};
-  position: relative;
-`;
-
-const CloseButton = styled(Close)`
-  position: absolute;
-  top: ${theme.spacing(1)};
-  right: ${theme.spacing(1)};
-`;
-
-const ImageUploader = styled.button`
-  margin: ${theme.spacing(1)};
-  border-radius: ${theme.spacing(5)};
-  background: none;
-  color: inherit;
-  border: ${theme.spacing(0.25)} solid ${theme.palette.grey[200]};
-  padding: 0;
-  font: inherit;
-  cursor: pointer;
-  outline: inherit;
-  width: ${theme.spacing(20)};
-  height: ${theme.spacing(20)};
-`;
-
-const ImagePreview = styled.img`
-  border-radius: ${theme.spacing(5)};
-  width: ${theme.spacing(20)};
-  height: ${theme.spacing(20)};
-`;
+import {
+  CloseButton,
+  FullWidthInput,
+  ImageItem,
+  ImagePreview,
+  ImageUploader,
+  ImageWrapper,
+  Rate,
+  Row,
+  SalesDateInfo,
+  Wave,
+} from './Package.css';
 
 const Package = (): React.ReactElement => {
   const [currentProductInput, setCurrentProductInput] = useRecoilState(

--- a/src/pages/CreateProduct/Package/index.tsx
+++ b/src/pages/CreateProduct/Package/index.tsx
@@ -1,5 +1,6 @@
 import { FormLabel, InputWithLabel, RequiredMark } from 'knitting/dumbs';
-import InlineInput from 'knitting/dumbs/InlineInput';
+import Accordion from 'knitting/dumbs/Accordion';
+import InlineInput, { FormLabel as Label } from 'knitting/dumbs/InlineInput';
 import { formatDate } from 'knitting/utils/format';
 
 import AdapterDateFns from '@mui/lab/AdapterDateFns';
@@ -21,12 +22,15 @@ import { useRecoilState } from 'recoil';
 import { currentProductInputAtom } from '../recoils';
 
 import {
+  AccordionDetail,
   CloseButton,
   FullWidthInput,
   ImageItem,
   ImagePreview,
   ImageUploader,
   ImageWrapper,
+  Name,
+  Price,
   Rate,
   Row,
   SalesDateInfo,
@@ -44,6 +48,7 @@ const Package = (): React.ReactElement => {
     specifiedSalesStartDate,
     specifiedSalesEndDate,
     tags,
+    designs,
   } = currentProductInput;
   const [images, setImages] = React.useState<ImageListType>([]);
   const [invalidPrice, setInvalidPrice] = React.useState<boolean>(false);
@@ -115,13 +120,6 @@ const Package = (): React.ReactElement => {
     });
   };
 
-  const onChangeFullPrice: InputProps['onChange'] = ({ currentTarget }) => {
-    setCurrentProductInput({
-      ...currentProductInput,
-      fullPrice: Number(currentTarget.value),
-    });
-  };
-
   const onChangeDiscountPrice: InputProps['onChange'] = ({ currentTarget }) => {
     setCurrentProductInput({
       ...currentProductInput,
@@ -154,6 +152,15 @@ const Package = (): React.ReactElement => {
     setImages(imageList);
   };
 
+  const renderDetailElements = () => {
+    return designs.map((design) => (
+      <AccordionDetail>
+        <Name>{design.name}</Name>
+        <Price>+ {design.price.toLocaleString()} 원</Price>
+      </AccordionDetail>
+    ));
+  };
+
   return (
     <form>
       <Grid container>
@@ -172,16 +179,15 @@ const Package = (): React.ReactElement => {
             판매가
             <RequiredMark />
           </FormLabel>
-          <InlineInput
-            id="fullPrice"
-            type="number"
-            label="정가"
-            variant="h6"
-            value={fullPrice}
-            aria-describedby="fullPrice"
-            endAdornment={<InputAdornment position="end">원</InputAdornment>}
-            onChange={onChangeFullPrice}
-          />
+          <Row container alignItems="center">
+            <Grid>
+              <Label variant="h6">정가</Label>
+            </Grid>
+            <Accordion
+              summary={`${fullPrice.toLocaleString()} 원`}
+              detailElements={renderDetailElements()}
+            />
+          </Row>
           <Row container>
             <InlineInput
               id="discountPrice"

--- a/src/pages/CreateProduct/SelectDesigns/index.tsx
+++ b/src/pages/CreateProduct/SelectDesigns/index.tsx
@@ -1,5 +1,6 @@
 import EmptyContent from 'knitting/dumbs/EmptyContent';
 import DesignItem from 'knitting/pages/MyInformation/components/DesignItem';
+import { DesignItemResponse } from 'knitting/pages/MyInformation/hooks/types';
 import { useMyDesigns } from 'knitting/pages/MyInformation/hooks/useMyDesigns';
 import { DEFAULT_LIST_LENGTH } from 'knitting/utils/requestType';
 
@@ -20,20 +21,26 @@ const SelectDesigns = (): React.ReactElement => {
   const [currentProductInput, setCurrentProductInput] = useRecoilState(
     currentProductInputAtom,
   );
-  const { designIds } = currentProductInput;
+  const { designs: selectDesigns } = currentProductInput;
 
   const isEmpty = !isLoading && designs.length === 0;
 
-  const handleSelectDesign = (id: number) => (): void => {
-    let newDesignIds;
+  const handleSelectDesign = (design: DesignItemResponse) => (): void => {
+    let newDesigns;
 
-    if (designIds.find((designId) => designId === id)) {
-      newDesignIds = designIds.filter((designId) => designId !== id);
+    if (selectDesigns.find(({ id }) => id === design.id)) {
+      newDesigns = selectDesigns.filter(({ id }) => id !== design.id);
     } else {
-      newDesignIds = designIds.concat(id);
+      newDesigns = selectDesigns.concat(design);
     }
 
-    setCurrentProductInput({ ...currentProductInput, designIds: newDesignIds });
+    setCurrentProductInput({
+      ...currentProductInput,
+      fullPrice: newDesigns
+        .map((newDesign) => newDesign.price)
+        .reduce((current, prev) => current + prev, 0),
+      designs: newDesigns,
+    });
   };
 
   return (
@@ -51,7 +58,7 @@ const SelectDesigns = (): React.ReactElement => {
         {(isLoading ? [...Array(DEFAULT_LIST_LENGTH)] : designs).map(
           (design, index) => {
             const showDivider = designs.length - 1 !== index;
-            const isChecked = designIds.includes(design?.id);
+            const isChecked = selectDesigns.some(({ id }) => id === design.id);
 
             return (
               <DesignItem
@@ -61,7 +68,7 @@ const SelectDesigns = (): React.ReactElement => {
                 {...design}
                 showDivider={showDivider}
                 checked={isChecked}
-                onClick={handleSelectDesign(design?.id)}
+                onClick={handleSelectDesign(design)}
               />
             );
           },

--- a/src/pages/CreateProduct/components/Footer/hooks/useSaveProduct.ts
+++ b/src/pages/CreateProduct/components/Footer/hooks/useSaveProduct.ts
@@ -1,7 +1,6 @@
 import { FAILED_TO_SAVE_PRODUCT } from 'knitting/constants/errors';
 import { usePost } from 'knitting/hooks/usePost';
 import {
-  currentProductIdAtom,
   currentProductInputAtom,
   currentStepAtom,
 } from 'knitting/pages/CreateProduct/recoils';
@@ -16,7 +15,6 @@ type SaveProduct = {
 
 export const useSaveProduct = (): SaveProduct => {
   const setCurrentStep = useSetRecoilState(currentStepAtom);
-  const setCurrentProductId = useSetRecoilState(currentProductIdAtom);
 
   const {
     name,
@@ -26,7 +24,7 @@ export const useSaveProduct = (): SaveProduct => {
     specifiedSalesStartDate,
     specifiedSalesEndDate,
     tags,
-    designIds,
+    designs,
   } = useRecoilValue(currentProductInputAtom);
 
   const onSuccess = () => {
@@ -53,7 +51,7 @@ export const useSaveProduct = (): SaveProduct => {
       specified_sales_start_date: specifiedSalesStartDate,
       specified_sales_end_date: specifiedSalesEndDate,
       tags: splitText(tags, '#'),
-      design_ids: designIds,
+      design_ids: designs.map((design) => design.id),
     };
 
     mutate(postProductData);

--- a/src/pages/CreateProduct/recoils.ts
+++ b/src/pages/CreateProduct/recoils.ts
@@ -17,7 +17,7 @@ export const currentProductInputAtom = atom<ProductInput>({
     specifiedSalesStartDate: null,
     specifiedSalesEndDate: null,
     tags: '',
-    designIds: [],
+    designs: [],
   },
 });
 

--- a/src/pages/CreateProduct/types.ts
+++ b/src/pages/CreateProduct/types.ts
@@ -1,5 +1,7 @@
 import { SnakeToCamelCase } from 'knitting/utils/types';
 
+import { DesignItemResponse } from '../MyInformation/hooks/types';
+
 export const PAGE = {
   DESIGN: 0,
   PACKAGE: 1,
@@ -24,6 +26,10 @@ export type PostProductInput = {
   tags: string[];
 };
 
-export type ProductInput = Omit<SnakeToCamelCase<PostProductInput>, 'tags'> & {
+export type ProductInput = Omit<
+  SnakeToCamelCase<PostProductInput>,
+  'tags' | 'designIds'
+> & {
   tags: string;
+  designs: DesignItemResponse[];
 };

--- a/src/pages/MyInformation/components/DesignItem/index.tsx
+++ b/src/pages/MyInformation/components/DesignItem/index.tsx
@@ -1,11 +1,11 @@
 import { Ellipsis } from 'knitting/components';
 import Skeleton from 'knitting/dumbs/Skeleton';
+import { DesignItemResponse } from 'knitting/pages/MyInformation/hooks/types';
 import { theme } from 'knitting/themes';
 import { formatDate } from 'knitting/utils/format';
 
+import { Checkbox } from '@mui/material';
 import { MouseEvent } from 'react';
-
-import { DesignItemResponse } from '../../hooks/types';
 
 import {
   StyledListItemButton,
@@ -18,7 +18,6 @@ import {
   CreatedDate,
   ThumbNail,
   Divider,
-  StyledCheckBox,
   Price,
 } from './DesignItem.css';
 
@@ -47,12 +46,7 @@ const DesignItem = ({
     <StyledListItemButton onClick={onClick}>
       <ListItemContainer>
         {showCheckBox && (
-          <StyledCheckBox
-            color="primary"
-            edge="start"
-            checked={checked}
-            disableRipple
-          />
+          <Checkbox edge="start" checked={checked} disableRipple />
         )}
         {(isLoading || coverImageUrl) && (
           <ImageWrapper>


### PR DESCRIPTION
## PR 제안 사유
도안 등록 > 상품 구성하기 단계에서 가격을 아코디언으로 표시합니다.

Resolve #[1vru2yt](https://app.clickup.com/t/1vru2yt)

<!--
왜 이 PR을 제안하게 되었는지 간략하게 적어주세요.
이슈 내용만으로 설명이 된다면 생략 가능합니다.
-->

## 주요 변경 기록
- 상품 구성하기 페이지에 있던 styled-components를 `Package.css.ts` 파일로 분리합니다.
- `dumbs/Accordion` 컴포넌트를 추가합니다. 
    - props로 title과 아코디언 펼쳤을 때의 하위 엘리먼트들을 받고있는데, 더 좋은 구조를 고민해봐야할 것 같습니다.
- `designsId`를 `designs`로 변경합니다.
    - API 호출할 땐 `designsId`로 보내고, 도안 선택 이후 단계인 상품 구성하기 단계에서 도안 가격, 이름 등을 사용해야해서 `currentProductInput` 상태에서는 `designs`를 관리하도록 합니다.
- 도안 선택하기 단계에서 아래와 같이 체크박스가 노출되길래 잘 보이도록 수정했습니다. 기존 `StyledCheckBox`는 제거하지 않았습니다. (삭제해도 되는건지 한번 확인 부탁드려욥)
<img width="846" alt="Screenshot 2022-03-09 at 9 29 18 PM" src="https://user-images.githubusercontent.com/43168524/157467379-a771ba97-5886-43cb-9234-de99232c32c3.png">

<!--
간단하게라도 적어주세요.
변경된 자세한 내용을 적어주셔도 좋습니다.
-->

## Code review

### Code review 에서 중점적으로 봐야하는 부분
- 아코디언 컴포넌트에서 props 관리
- StyledCheckBox 를 사용하지 않고 mui의 Checkbox를 사용해도 되는지
<!-- 생략 가능합니다. -->

## Design review

### Design review 에서 중점적으로 봐야하는 부분 / 스크린샷

<!-- 생략 가능합니다. -->

## 기타 질문 및 특이 사항

<!-- 생략 가능합니다. -->
