### PR TITLE
[Feat] 도안, 상품 개수 표시

### DIFF
--- a/src/pages/MyInformation/components/CountIcon/CountIcon.css.ts
+++ b/src/pages/MyInformation/components/CountIcon/CountIcon.css.ts
@@ -1,0 +1,18 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const Icon = styled.div`
+  border-radius: 50%;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: bold;
+  ${({ theme }) => css`
+    background-color: ${theme.palette.primary.main};
+    color: ${theme.palette.common.white};
+    width: ${theme.spacing(2.5)};
+    height: ${theme.spacing(2.5)};
+    font-size: ${theme.spacing(1.5)};
+  `}
+`;

--- a/src/pages/MyInformation/components/CountIcon/CountIcon.css.ts
+++ b/src/pages/MyInformation/components/CountIcon/CountIcon.css.ts
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 
 export const Icon = styled.div`
   border-radius: 50%;
-
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/pages/MyInformation/components/CountIcon/index.tsx
+++ b/src/pages/MyInformation/components/CountIcon/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import { Icon } from './CountIcon.css';
+
+type P = {
+  count: number;
+};
+
+const CountIcon = ({ count }: P): React.ReactElement => {
+  return <Icon>{count}</Icon>;
+};
+
+export default CountIcon;

--- a/src/pages/MyInformation/components/CountIcon/index.tsx
+++ b/src/pages/MyInformation/components/CountIcon/index.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 
 import { Icon } from './CountIcon.css';
 
-type P = {
+type Props = {
   count: number;
 };
 
-const CountIcon = ({ count }: P): React.ReactElement => {
+const CountIcon = ({ count }: Props): React.ReactElement => {
   return <Icon>{count}</Icon>;
 };
 

--- a/src/pages/MyInformation/components/InformationTabs/InformationTabs.css.ts
+++ b/src/pages/MyInformation/components/InformationTabs/InformationTabs.css.ts
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+import { Tab } from '@mui/material';
+
+export const StyledTab = styled(Tab)`
+  display: flex;
+  justify-content: space-around;
+  width: 270px;
+  font-size: ${({ theme }) => theme.spacing(1.75)};
+  font-weight: bold;
+  min-height: auto;
+`;

--- a/src/pages/MyInformation/components/InformationTabs/index.tsx
+++ b/src/pages/MyInformation/components/InformationTabs/index.tsx
@@ -1,4 +1,5 @@
 import { selectedTabAtom } from 'knitting/pages/MyInformation/atom';
+import { useMySummary } from 'knitting/pages/MyInformation/hooks/useMySummary';
 import {
   DESIGN_MENU_TYPE,
   DESIGN_MENU,
@@ -16,6 +17,8 @@ import { StyledTab } from './InformationTabs.css';
 
 const MyInformationTabs = (): React.ReactElement => {
   const [selectedTab, setSelectedTab] = useRecoilState(selectedTabAtom);
+  const { myDesignsCount, myProductsCount, purchasedProductsCount } =
+    useMySummary();
 
   const handleChange = (
     _event: React.SyntheticEvent<Element, Event>,
@@ -35,20 +38,20 @@ const MyInformationTabs = (): React.ReactElement => {
         <StyledTab
           value={DESIGN_MENU.CREATED_DESIGN}
           label="내가 만든 도안"
-          icon={<CountIcon count={2} />}
+          icon={<CountIcon count={myDesignsCount} />}
           iconPosition="end"
         />
         <StyledTab
           value={DESIGN_MENU.DESIGN_ON_SALE}
           label="판매 중인 상품"
-          icon={<CountIcon count={2} />}
+          icon={<CountIcon count={myProductsCount} />}
           iconPosition="end"
           disabled
         />
         <StyledTab
           value={DESIGN_MENU.PURCHASED_DESIGN}
           label="구매한 상품"
-          icon={<CountIcon count={2} />}
+          icon={<CountIcon count={purchasedProductsCount} />}
           iconPosition="end"
           disabled
         />

--- a/src/pages/MyInformation/components/InformationTabs/index.tsx
+++ b/src/pages/MyInformation/components/InformationTabs/index.tsx
@@ -4,12 +4,15 @@ import {
   DESIGN_MENU,
 } from 'knitting/pages/MyInformation/types';
 
-import { Tab, Tabs } from '@mui/material';
+import { Tabs } from '@mui/material';
 import React from 'react';
 import { useRecoilState } from 'recoil';
 
+import CountIcon from '../CountIcon';
 import Designs from '../Designs';
 import InformationTabPanel from '../InformationTabPanel';
+
+import { StyledTab } from './InformationTabs.css';
 
 const MyInformationTabs = (): React.ReactElement => {
   const [selectedTab, setSelectedTab] = useRecoilState(selectedTabAtom);
@@ -29,15 +32,24 @@ const MyInformationTabs = (): React.ReactElement => {
         textColor="primary"
         indicatorColor="primary"
       >
-        <Tab value={DESIGN_MENU.CREATED_DESIGN} label="내가 만든 도안" />
-        <Tab
+        <StyledTab
+          value={DESIGN_MENU.CREATED_DESIGN}
+          label="내가 만든 도안"
+          icon={<CountIcon count={2} />}
+          iconPosition="end"
+        />
+        <StyledTab
           value={DESIGN_MENU.DESIGN_ON_SALE}
           label="판매 중인 상품"
+          icon={<CountIcon count={2} />}
+          iconPosition="end"
           disabled
         />
-        <Tab
+        <StyledTab
           value={DESIGN_MENU.PURCHASED_DESIGN}
           label="구매한 상품"
+          icon={<CountIcon count={2} />}
+          iconPosition="end"
           disabled
         />
       </Tabs>

--- a/src/pages/MyInformation/components/MyProfile/MyProfile.css.ts
+++ b/src/pages/MyInformation/components/MyProfile/MyProfile.css.ts
@@ -49,7 +49,7 @@ export const MySalesSummary = styled.div`
   display: flex;
   margin-top: ${theme.spacing(1.5)};
 
-  > div:first-child {
+  > div:first-of-type {
     margin-right: ${theme.spacing(3)};
   }
 `;

--- a/src/pages/MyInformation/components/MyProfile/index.tsx
+++ b/src/pages/MyInformation/components/MyProfile/index.tsx
@@ -1,8 +1,5 @@
 import { useCommonSnackbar } from 'knitting/components/CommonSnackbar/useCommonSnackbar';
-import {
-  FAILED_TO_GET_MY_SALE_SUMMARY,
-  FAILED_TO_GET_MY_PROFILE,
-} from 'knitting/constants/errors';
+import { FAILED_TO_GET_MY_PROFILE } from 'knitting/constants/errors';
 import EmptyContent from 'knitting/dumbs/EmptyContent';
 import { tabItemLengthAtom } from 'knitting/pages/MyInformation/atom';
 
@@ -12,7 +9,6 @@ import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 
 import { useGetMyProfile } from '../../hooks/useGetMyProfile';
-import { useGetMySalesSummary } from '../../hooks/useGetMySalesSummary';
 
 import {
   CreateButton,
@@ -30,8 +26,6 @@ import { useRenderButtonText } from './useRenderButtonText';
 const MyProfile = (): React.ReactElement => {
   const [createButtonText, handleButtonClick] = useRenderButtonText();
   const tabItemLength = useRecoilValue(tabItemLengthAtom);
-  const { error: salesSummaryError, data: salesSummaryData } =
-    useGetMySalesSummary();
   const { error: myProfileError, data: myProfileData } = useGetMyProfile();
   const navigate = useNavigate();
 
@@ -40,12 +34,6 @@ const MyProfile = (): React.ReactElement => {
     buttonText: '메인으로 돌아가기',
     onClick: () => navigate('/'),
   };
-
-  useCommonSnackbar({
-    message: FAILED_TO_GET_MY_SALE_SUMMARY,
-    severity: 'error',
-    dependencies: [salesSummaryError],
-  });
 
   useCommonSnackbar({
     message: FAILED_TO_GET_MY_PROFILE,
@@ -58,14 +46,6 @@ const MyProfile = (): React.ReactElement => {
   }
 
   const { email, profile_image_url, name } = myProfileData.payload;
-  const {
-    number_of_products_on_sales: numberOfProductsOnSales,
-    number_of_products_sold: numberOfProductsSold,
-  } = salesSummaryData?.payload ?? {
-    number_of_products_on_sales: 0,
-    number_of_products_sold: 0,
-  };
-
   const emptyList = tabItemLength === 0;
 
   return (
@@ -84,15 +64,11 @@ const MyProfile = (): React.ReactElement => {
           <MySalesSummary>
             <div>
               <Typography variant="caption">판매중인 상품</Typography>
-              <SalesSummaryCount variant="h5">
-                {numberOfProductsOnSales}
-              </SalesSummaryCount>
+              <SalesSummaryCount variant="h5">0</SalesSummaryCount>
             </div>
             <div>
               <Typography variant="caption">판매 수</Typography>
-              <SalesSummaryCount variant="h5">
-                {numberOfProductsSold}
-              </SalesSummaryCount>
+              <SalesSummaryCount variant="h5">0</SalesSummaryCount>
             </div>
           </MySalesSummary>
         </div>

--- a/src/pages/MyInformation/hooks/useMySummary.ts
+++ b/src/pages/MyInformation/hooks/useMySummary.ts
@@ -1,0 +1,22 @@
+import { useGet } from 'knitting/hooks/useGet';
+import { ObjectResponse } from 'knitting/utils/requestType';
+
+import { SummaryResponse } from '../types';
+
+export const useMySummary = () => {
+  const { data } = useGet<ObjectResponse<SummaryResponse>>({
+    pathname: '/me/profile/summary',
+  });
+
+  return data
+    ? {
+        myDesignsCount: data.payload.my_designs_count,
+        myProductsCount: data.payload.my_products_count,
+        purchasedProductsCount: data.payload.purchased_products_count,
+      }
+    : {
+        myDesignsCount: 0,
+        myProductsCount: 0,
+        purchasedProductsCount: 0,
+      };
+};

--- a/src/pages/MyInformation/types.ts
+++ b/src/pages/MyInformation/types.ts
@@ -1,3 +1,5 @@
+import { SnakeToCamelCase } from 'knitting/utils/types';
+
 export const DESIGN_MENU = {
   CREATED_DESIGN: 'created_design',
   DESIGN_ON_SALE: 'design_on_sale',
@@ -5,3 +7,11 @@ export const DESIGN_MENU = {
 } as const;
 
 export type DESIGN_MENU_TYPE = typeof DESIGN_MENU[keyof typeof DESIGN_MENU];
+
+export type SummaryResponse = {
+  my_designs_count: number;
+  my_products_count: number;
+  purchased_products_count: number;
+};
+
+export type Summary = SnakeToCamelCase<SummaryResponse>;


### PR DESCRIPTION
Resolve #[2cxzh6h](https://app.clickup.com/t/2cxzh6h)

## 주요 변경 기록
- `/my`에서 도안 개수와 판매 상품 개수 표시
- `/me/sales-summary` 연동하는 부분 제거

<!--
간단하게라도 적어주세요.
변경된 자세한 내용을 적어주셔도 좋습니다.
-->

## Code review

### Code review 에서 중점적으로 봐야하는 부분

<!-- 생략 가능합니다. -->

## Design review

### Design review 에서 중점적으로 봐야하는 부분 / 스크린샷
![image](https://user-images.githubusercontent.com/43168524/159852060-fe78910b-6682-4b0f-8594-c1dbf74c7d35.png)

<!-- 생략 가능합니다. -->

## 기타 질문 및 특이 사항

<!-- 생략 가능합니다. -->
