### PR TITLE
[Feat] footer에 샘플도안 & 가이드 다운 영역 추가

### DIFF
--- a/src/dumbs/Button/index.tsx
+++ b/src/dumbs/Button/index.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { Button as MaterialButton } from '@mui/material';
+import { Button as MaterialButton, ButtonProps } from '@mui/material';
 import React from 'react';
 
 export const SIDE = {
@@ -10,7 +10,7 @@ export const SIDE = {
 
 export type SIDE_TYPE = typeof SIDE[keyof typeof SIDE];
 
-export interface Props {
+export interface Props extends ButtonProps {
   side?: SIDE_TYPE;
   label: string;
   onClick?(): void;

--- a/src/pages/EditDesign/components/Footer/Footer.css.ts
+++ b/src/pages/EditDesign/components/Footer/Footer.css.ts
@@ -1,4 +1,7 @@
+import Button from 'knitting/dumbs/Button';
+
 import styled from '@emotion/styled';
+import { Alert } from '@mui/material';
 
 export const FooterContainer = styled.div`
   display: flex;
@@ -20,4 +23,12 @@ export const NextContainer = styled.div`
     margin-top: ${({ theme }) => theme.spacing(1)};
     color: ${({ theme }) => theme.palette.error.main};
   }
+`;
+
+export const DownloadAlert = styled(Alert)`
+  background-color: ${({ theme }) => theme.palette.grey[300]};
+`;
+
+export const DownloadButton = styled(Button)`
+  margin-left: ${({ theme }) => theme.spacing(2)};
 `;

--- a/src/pages/EditDesign/components/Footer/index.tsx
+++ b/src/pages/EditDesign/components/Footer/index.tsx
@@ -30,14 +30,14 @@ const Footer = ({
   onNextClick,
 }: FooterProps): ReactElement => {
   const [open, setOpen] = useState<boolean>(
-    localStorage.getItem('popup')
-      ? localStorage.getItem('popup') === 'true'
+    localStorage.getItem('showDesignGuide')
+      ? localStorage.getItem('showDesignGuide') === 'true'
       : true,
   );
 
   const handleClose = () => {
     setOpen(false);
-    localStorage.setItem('popup', JSON.stringify(false));
+    localStorage.setItem('showDesignGuide', JSON.stringify(false));
   };
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function,@typescript-eslint/no-unused-vars

--- a/src/pages/EditDesign/components/Footer/index.tsx
+++ b/src/pages/EditDesign/components/Footer/index.tsx
@@ -1,7 +1,18 @@
-import { Button as MaterialButton } from '@mui/material';
-import React, { ReactElement, ReactNode } from 'react';
+import CloseIcon from '@mui/icons-material/Close';
+import {
+  Button as MaterialButton,
+  Box,
+  Collapse,
+  IconButton,
+} from '@mui/material';
+import React, { ReactElement, ReactNode, useState } from 'react';
 
-import { FooterContainer, NextContainer } from './Footer.css';
+import {
+  FooterContainer,
+  NextContainer,
+  DownloadAlert,
+  DownloadButton,
+} from './Footer.css';
 
 interface FooterProps {
   previousLabel: ReactNode;
@@ -18,22 +29,69 @@ const Footer = ({
   onPreviousClick,
   onNextClick,
 }: FooterProps): ReactElement => {
+  const [open, setOpen] = useState<boolean>(
+    localStorage.getItem('popup')
+      ? localStorage.getItem('popup') === 'true'
+      : true,
+  );
+
+  const handleClose = () => {
+    setOpen(false);
+    localStorage.setItem('popup', JSON.stringify(false));
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function,@typescript-eslint/no-unused-vars
+  const handleDownload = (type: 'sample' | 'guide') => {};
+
   return (
-    <FooterContainer>
-      <MaterialButton variant="contained" onClick={onPreviousClick}>
-        {previousLabel}
-      </MaterialButton>
-      <NextContainer>
-        <MaterialButton
-          variant="contained"
-          disabled={invalidMessage != null}
-          onClick={onNextClick}
-        >
-          {nextLabel}
+    <>
+      <FooterContainer>
+        <MaterialButton variant="contained" onClick={onPreviousClick}>
+          {previousLabel}
         </MaterialButton>
-        {invalidMessage && <span>{invalidMessage}</span>}
-      </NextContainer>
-    </FooterContainer>
+        <NextContainer>
+          <MaterialButton
+            variant="contained"
+            disabled={invalidMessage != null}
+            onClick={onNextClick}
+          >
+            {nextLabel}
+          </MaterialButton>
+          {invalidMessage && <span>{invalidMessage}</span>}
+        </NextContainer>
+      </FooterContainer>
+      <Box sx={{ width: '100%' }}>
+        <Collapse in={open}>
+          <DownloadAlert
+            severity="info"
+            action={
+              <IconButton
+                aria-label="close"
+                color="inherit"
+                size="small"
+                onClick={handleClose}
+              >
+                <CloseIcon fontSize="inherit" />
+              </IconButton>
+            }
+            sx={{ mb: 2 }}
+          >
+            샘플도안과 가이드를 통해 어떻게 도안이 만들어지는지 확인할 수
+            있어요! 🧚‍
+            <DownloadButton
+              label="샘플 도안 다운"
+              variant="outlined"
+              onClick={() => handleDownload('sample')}
+            />
+            <DownloadButton
+              label="작성 가이드 다운"
+              variant="outlined"
+              onClick={() => handleDownload('guide')}
+            />
+          </DownloadAlert>
+        </Collapse>
+      </Box>
+    </>
   );
 };
 


### PR DESCRIPTION

[Click Up 이슈 링크](https://app.clickup.com/t/2fz7zmm)

## 주요 변경 기록
- 도안 생성 페이지 하단에 샘플 도안 및 가이드 다운 alert 추가

<!--
간단하게라도 적어주세요.
변경된 자세한 내용을 적어주셔도 좋습니다.
-->

## Code review

### Code review 에서 중점적으로 봐야하는 부분

<!-- 생략 가능합니다. -->

## Design review

### Design review 에서 중점적으로 봐야하는 부분 / 스크린샷
![image](https://user-images.githubusercontent.com/43168524/167430844-bdfbd8d2-862b-43c0-8460-21fa727a9163.png)

<!-- 생략 가능합니다. -->

## 기타 질문 및 특이 사항

<!-- 생략 가능합니다. -->
